### PR TITLE
Support for install_uifile.sh, upgrade_uifile.sh and uninstall_uifile.sh files

### DIFF
--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -36,7 +36,7 @@ class SPK(object):
     package_re = re.compile(r'^[\w-]+$')
 
     #: Regex for a wizard filename
-    wizard_filename_re = re.compile(r'^WIZARD_UIFILES/(?P<process>install|upgrade|uninstall)_uifile(?:_[a-z]{3})?$')
+    wizard_filename_re = re.compile(r'^WIZARD_UIFILES/(?P<process>install|upgrade|uninstall)_uifile(?:_[a-z]{3})?(?:\.sh)?$')
 
     #: Regex for icons in INFO
     icon_info_re = re.compile(r'^package_icon(?:_(?P<size>120|256))?$')


### PR DESCRIPTION
Documentation: https://developer.synology.com/developer-guide/synology_package/WIZARD_UIFILES.html

install_uifile.sh, upgrade_uifile.sh, uninstall_uifile.sh and *.sh scripts to generate the wizard dynamically are only supported in DSM 5.2 or newer.

Fixes https://github.com/SynoCommunity/spksrc/issues/3389