### PR TITLE
Improve package view

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -335,7 +335,10 @@ class Build(db.Model):
     # Relationships
     version = db.relationship("Version", back_populates="builds", lazy=False)
     architectures = db.relationship(
-        "Architecture", secondary="build_architecture", lazy=False
+        "Architecture",
+        secondary="build_architecture",
+        order_by="Architecture.code",
+        lazy=False,
     )
     firmware = db.relationship("Firmware", lazy=False)
     publisher = db.relationship("User", foreign_keys=[publisher_user_id])
@@ -469,6 +472,13 @@ class Version(db.Model):
 
     def __repr__(self):
         return "<{} {}>".format(self.__class__.__name__, self.version_string)
+
+    @hybrid_property
+    def builds_per_dsm(self):
+        result = {}
+        for build in self.builds:
+            result.setdefault(build.firmware.version[0:1], []).append(build)
+        return result
 
 
 class Package(db.Model):

--- a/spkrepo/static/css/spkrepo.css
+++ b/spkrepo/static/css/spkrepo.css
@@ -52,6 +52,15 @@
     height: 100px;
 }
 
+.package-screenshots {
+    text-align: center;
+    padding: 5px 0;
+}
+
+.package-screenshot {
+    height: 100px;
+}
+
 .fastly-logo {
     width: auto;
     height: 45px;

--- a/spkrepo/templates/frontend/package.html
+++ b/spkrepo/templates/frontend/package.html
@@ -1,7 +1,6 @@
 {% extends 'base.html' %}
 {% block title %}{{ package.versions[-1].displaynames['enu'].displayname }} Package - {{ super() }}{% endblock %}
 {% block content %}
-{# TODO: Improve this template #}
 <div class="row">
   <div class="media">
     <a class="media-left" href="#">
@@ -14,19 +13,38 @@
         </small>
       </h1>
       <p>{{ package.versions[-1].descriptions['enu'].description }}</p>
+      <div class="package-screenshots">
+        {% for screenshot in package.screenshots %}
+        <img class="package-screenshot" src="{{ url_for('nas.data', path=screenshot.path) }}"/>&nbsp;
+        {% endfor %}
+      </div>
+      {% for version in package.versions|reverse %}
       <dl>
+        <dt>Version {{ version.version_string | safe }}</dt>
+        <dd>{{ version.changelog | safe }}</dd>
+        <dt>Date</dt>
+        <dd>{{ version.insert_date }}</dd>
         <dt>Architectures</dt>
         <dd>
-          {% for build in package.versions[-1].builds %}
+          {% for (version, builds) in version.builds_per_dsm.items() %}
+          <!-- Group firmware by DSM or SRM if 1.x -->
+          {% if version == '1' %}
+          SRM {{ version }}.x:
+          {% else %}
+          DSM {{ version }}.x:
+          {% endif %}
+          {% for build in builds %}
           {% for arch in build.architectures %}
-          <span class="label label-default">{{ arch.code }}</span>
+          <a href="{{ url_for('nas.data', path=build.path) }}"><span class="label label-default">{{ build.firmware.version }} {{ arch.code }}</span></a>
           {% endfor %}
+          {% endfor %}
+          <br/>
           {% endfor %}
         </dd>
-        <dt>Author</dt>
-        <dd>{{ package.author.username }}</dd>
       </dl>
+      {% endfor %}
     </div>
+    <span
   </div>
 </div>
 {% endblock %}

--- a/spkrepo/tests/test_frontend.py
+++ b/spkrepo/tests/test_frontend.py
@@ -85,10 +85,6 @@ class PackageTestCase(BaseTestCase):
         for a in build.architectures:
             self.assertIn(a.code, response.data.decode(response.charset))
         self.assertIn(
-            build.version.package.author.username,
-            response.data.decode(response.charset),
-        )
-        self.assertIn(
             build.version.displaynames["enu"].displayname,
             response.data.decode(response.charset),
         )


### PR DESCRIPTION
Improved package view that already run in production for a while

- List all versions
- List architectures with direct package link
- Group architectures per DSM version
- Sort architectures
- Show screenshot
- Allow < br /> rendering in changelog