### PR TITLE
Improve exception handling

### DIFF
--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -250,7 +250,7 @@ class Packages(Resource):
                     current_app.config["GNUPG_PATH"],
                 )
             except SPKSignError as e:
-                abort(500, message="Failed to sign package", details=e.message)
+                abort(500, message="Failed to sign package", details=str(e))
 
         # save files
         try:
@@ -275,7 +275,7 @@ class Packages(Resource):
                     os.remove(os.path.join(data_path, build.path))
                 except OSError:
                     pass
-            abort(500, message="Failed to save files", details=e.message)
+            abort(500, message="Failed to save files", details=str(e))
 
         # insert the package into database
         db.session.add(build)


### PR DESCRIPTION
In diagnosing the publishing process, errors like `FileNotFoundError` (and likely other `IOError` types) have no 'message' attribute in the exception object. This results in another exception in the handling of the primary exception which is not good for logging. This PR attempts to improve the exception handling by using the safer `str(e)` instead.

Fixes: #50