### PR TITLE
Implement package filter for active build

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -444,6 +444,10 @@ class Version(db.Model):
     def all_builds_active(self):
         return all(b.active for b in self.builds)
 
+    @hybrid_property
+    def any_builds_active(self):
+        return any(b.active for b in self.builds)
+
     @all_builds_active.expression
     def all_builds_active(cls):
         return (
@@ -531,6 +535,10 @@ class Package(db.Model):
 
     # Constraints
     __table_args__ = (db.UniqueConstraint(name),)
+
+    @hybrid_property
+    def any_builds_active(self):
+        return any(v.any_builds_active for v in self.versions)
 
     @classmethod
     def find(cls, name):

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -98,7 +98,7 @@ def packages():
 def package(name):
     # show only packages with at least a version and an active build
     package = Package.query.filter_by(name=name).first()
-    if package is None or not package.any_builds_active():
+    if package is None or not package.any_builds_active:
         abort(404)
     return render_template("frontend/package.html", package=package)
 

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -96,9 +96,9 @@ def packages():
 
 @frontend.route("/package/<name>")
 def package(name):
-    # TODO: show only packages with at least a version and an active build
+    # show only packages with at least a version and an active build
     package = Package.query.filter_by(name=name).first()
-    if package is None:
+    if package is None or not package.any_builds_active():
         abort(404)
     return render_template("frontend/package.html", package=package)
 


### PR DESCRIPTION
In displaying the details of a package as a webpage, there was only a filter to show the package if it exists. There was not a filter to verify that there were any active builds for that package. This PR attempts to implement this filter which was previously left as a todo.

This partially addresses #97.