### PR TITLE
Template fix to show only active builds

### DIFF
--- a/spkrepo/templates/frontend/package.html
+++ b/spkrepo/templates/frontend/package.html
@@ -34,9 +34,11 @@
           DSM {{ version }}.x:
           {% endif %}
           {% for build in builds %}
+          {% if build.active %}
           {% for arch in build.architectures %}
           <a href="{{ url_for('nas.data', path=build.path) }}"><span class="label label-default">{{ build.firmware.version }} {{ arch.code }}</span></a>
           {% endfor %}
+          {% endif %}
           {% endfor %}
           <br/>
           {% endfor %}


### PR DESCRIPTION
On the package details page, it would display both active and inactive builds as there was no filter to only show what was active. This PR attempts to patch the frontend template to address this.

Fixes: #97.