### PR TITLE
Make a directory safely without raising error

### DIFF
--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -256,9 +256,9 @@ class Packages(Resource):
         try:
             data_path = current_app.config["DATA_PATH"]
             if create_package:
-                os.mkdir(os.path.join(data_path, package.name))
+                os.makedirs(os.path.join(data_path, package.name), exist_ok=True)
             if create_version:
-                os.mkdir(os.path.join(data_path, package.name, str(version.version)))
+                os.makedirs(os.path.join(data_path, package.name, str(version.version)), exist_ok=True)
                 for size, icon in build.version.icons.items():
                     icon.save(spk.icons[size])
             build.save(spk.stream)


### PR DESCRIPTION
During the upload of SPK files, if this is for a new package or version, folders and corresponding database entries are created. During this process, if there are multiple concurrent requests there is a risk that one process may be attempting to create a folder after another process has already done so. This would result in an exception that can cause the cleanup of folders to occur and put the system into an inconsistent state. This PR changes the way folders are created to not raise an error if one already exists to avoid this.

Fixes: https://github.com/SynoCommunity/spkrepo/issues/95