### PR TITLE
Improve packages webui

### DIFF
--- a/spkrepo/templates/frontend/package.html
+++ b/spkrepo/templates/frontend/package.html
@@ -8,9 +8,7 @@
     </a>
     <div class="media-body">
       <h1 class="media-heading">{{ package.versions[-1].displaynames['enu'].displayname }}
-        <small>v{{ package.versions[-1].version_string }}
-          {% if package.versions[-1].report_url %}<span class="label label-danger">beta</span>{% endif %}
-        </small>
+        <small>v{{ package.versions[-1].version_string }}</small>
       </h1>
       <p>{{ package.versions[-1].descriptions['enu'].description }}</p>
       <div class="package-screenshots">
@@ -20,31 +18,36 @@
       </div>
       {% for version in package.versions|reverse %}
       <dl>
-        <dt>Version {{ version.version_string | safe }}</dt>
+        <dt>Version {{ version.version_string | safe }}{% if version.report_url %} <span class="label label-danger">beta</span>{% endif %}</dt>
         <dd>{{ version.changelog | safe }}</dd>
         <dt>Date</dt>
-        <dd>{{ version.insert_date }}</dd>
+        <dd>{{ version.insert_date.replace(microsecond=0) }}</dd>
         <dt>Architectures</dt>
         <dd>
-          {% for (version, builds) in version.builds_per_dsm.items() %}
+        {% for (version, builds) in version.builds_per_dsm.items() %}
           <!-- Group firmware by DSM or SRM if 1.x -->
           {% if version == '1' %}
-          SRM {{ version }}.x:
+            SRM {{ version }}.x:
           {% else %}
-          DSM {{ version }}.x:
+            DSM {{ version }}.x:
           {% endif %}
           {% for build in builds %}
-          {% for arch in build.architectures %}
-          <a href="{{ url_for('nas.data', path=build.path) }}"><span class="label label-default">{{ build.firmware.version }} {{ arch.code }}</span></a>
-          {% endfor %}
+            {% if build.active %}
+              {% for arch in build.architectures %}
+              <a href="{{ url_for('nas.data', path=build.path) }}"><span class="label label-success">{{ build.firmware.version }} {{ arch.code }}</span></a>
+              {% endfor %}
+            {% else %}
+              {% for arch in build.architectures %}
+              <a href="{{ url_for('nas.data', path=build.path) }}"><span class="label label-default" data-toggle="tooltip" title="Inactive: Manual installation only. This Package might be under development and have pending issues.">{{ build.firmware.version }} {{ arch.code }}</span></a>
+              {% endfor %}
+            {% endif %}
           {% endfor %}
           <br/>
-          {% endfor %}
+        {% endfor %}
         </dd>
       </dl>
       {% endfor %}
     </div>
-    <span
   </div>
 </div>
 {% endblock %}

--- a/spkrepo/templates/frontend/packages.html
+++ b/spkrepo/templates/frontend/packages.html
@@ -12,9 +12,7 @@
         </a>
         <div class="media-body">
           <h4 class="media-heading">{{ version.displaynames['enu'].displayname }}
-            <small>v{{ version.version_string }}
-              {% if version.report_url %}<span class="label label-danger">beta</span>{% endif %}
-            </small>
+            <small>v{{ version.version_string }}</small>
           </h4>
           <div class="ellipsis package-description">
             <p>{{ version.descriptions['enu'].description }}</p>

--- a/spkrepo/templates/layout.html
+++ b/spkrepo/templates/layout.html
@@ -90,9 +90,9 @@
 
     <footer class="footer" role="contentinfo">
       <div class="container">
-        <p>Powered by <a href="https://github.com/Diaoul/spkrepo">spkrepo</a>.</p>
-        <p>Developed by <a href="https://github.com/Diaoul">Antoine Bertin</a>.</p>
-        <p>Code licensed under <a href="https://github.com/Diaoul/spkrepo/blob/master/LICENSE" target="_blank">MIT</a>.</p>
+        <p>Designed by Antoine Bertin.</p>
+        <p>Maintained by <a href="https://github.com/orgs/SynoCommunity/people">SynoCommunity</a> with the help of <a href="https://github.com/SynoCommunity/spksrc/graphs/contributors">contributors</a>.</p>
+        <p>Code licensed under <a href="https://github.com/SynoCommunity/spkrepo/blob/master/LICENSE" target="_blank">MIT</a>.</p>
       </div>
     </footer>
 

--- a/spkrepo/templates/security/login_user.html
+++ b/spkrepo/templates/security/login_user.html
@@ -3,5 +3,4 @@
 {% block content %}
 <h1>Login</h1>
 {{ wtf.quick_form(login_user_form, field_order=['email'], button_map={'submit': 'primary'}) }}
-<p><a href="{{ url_for('security.forgot_password') }}">I forgot my password</a></p>
 {% endblock %}

--- a/spkrepo/tests/test_frontend.py
+++ b/spkrepo/tests/test_frontend.py
@@ -12,38 +12,45 @@ class IndexTestCase(BaseTestCase):
     def test_get_anonymous(self):
         response = self.client.get(url_for("frontend.index"))
         self.assert200(response)
-        self.assertIn("Login", response.data.decode())
-        self.assertIn("Register", response.data.decode())
+        response_data = response.data.decode()
+        self.assertIn("Login", response_data)
+        self.assertIn("Register", response_data)
 
     def test_get_logged_user(self):
         with self.logged_user():
             response = self.client.get(url_for("frontend.index"))
             self.assert200(response)
-            self.assertIn("Logout", response.data.decode())
-            self.assertIn("Profile", response.data.decode())
+            response_data = response.data.decode()
+            self.assertIn("Logout", response_data)
+            self.assertIn("Profile", response_data)
 
 
 class PackagesTestCase(BaseTestCase):
-    def test_get_active(self):
+    # Assert beta is not shown on Packages page
+    def test_get_active_not_stable(self):
         build = BuildFactory(version__report_url=None, active=True)
         db.session.commit()
         response = self.client.get(url_for("frontend.packages"))
         self.assert200(response)
+        response_data = response.data.decode()
         self.assertIn(
             build.version.displaynames["enu"].displayname,
-            response.data.decode(),
+            response_data,
         )
-        self.assertNotIn("beta", response.data.decode())
+        self.assertNotIn("beta", response_data)
 
-    def test_get_not_active(self):
+    # Assert package with only inactive version(s) is shown on Packages page
+    def test_get_not_active_not_stable(self):
         build = BuildFactory(active=False)
         db.session.commit()
         response = self.client.get(url_for("frontend.packages"))
         self.assert200(response)
+        response_data = response.data.decode()
         self.assertIn(
             build.version.displaynames["enu"].displayname,
-            response.data.decode(),
+            response_data,
         )
+        self.assertNotIn("beta", response_data)
 
 
 class PackageTestCase(BaseTestCase):
@@ -58,17 +65,19 @@ class PackageTestCase(BaseTestCase):
             url_for("frontend.package", name=build.version.package.name)
         )
         self.assert200(response)
+        response_data = response.data.decode()
         for a in build.architectures:
-            self.assertIn(a.code, response.data.decode())
+            self.assertIn(a.code, response_data)
         self.assertIn(
             build.version.displaynames["enu"].displayname,
-            response.data.decode(),
+            response_data,
         )
         self.assertIn(
             build.version.descriptions["enu"].description,
-            response.data.decode(),
+            response_data,
         )
-        self.assertNotIn("beta", response.data.decode())
+        self.assertNotIn("beta", response_data)
+        self.assertIn("label label-success", response_data)
 
     def test_get_not_active_stable(self):
         build = BuildFactory(
@@ -81,17 +90,19 @@ class PackageTestCase(BaseTestCase):
             url_for("frontend.package", name=build.version.package.name)
         )
         self.assert200(response)
+        response_data = response.data.decode()
         for a in build.architectures:
-            self.assertIn(a.code, response.data.decode())
+            self.assertIn(a.code, response_data)
         self.assertIn(
             build.version.displaynames["enu"].displayname,
-            response.data.decode(),
+            response_data,
         )
         self.assertIn(
             build.version.descriptions["enu"].description,
-            response.data.decode(),
+            response_data,
         )
-        self.assertNotIn("beta", response.data.decode())
+        self.assertNotIn("beta", response_data)
+        self.assertIn("label label-default", response_data)
 
     def test_get_active_not_stable(self):
         build = BuildFactory(
@@ -103,17 +114,19 @@ class PackageTestCase(BaseTestCase):
             url_for("frontend.package", name=build.version.package.name)
         )
         self.assert200(response)
+        response_data = response.data.decode()
         for a in build.architectures:
-            self.assertIn(a.code, response.data.decode())
+            self.assertIn(a.code, response_data)
         self.assertIn(
             build.version.displaynames["enu"].displayname,
-            response.data.decode(),
+            response_data,
         )
         self.assertIn(
             build.version.descriptions["enu"].description,
-            response.data.decode(),
+            response_data,
         )
-        self.assertIn("beta", response.data.decode())
+        self.assertIn("beta", response_data)
+        self.assertIn("label label-success", response_data)
 
     def test_get_not_active_not_stable(self):
         build = BuildFactory(
@@ -125,17 +138,20 @@ class PackageTestCase(BaseTestCase):
             url_for("frontend.package", name=build.version.package.name)
         )
         self.assert200(response)
+        response_data = response.data.decode()
         for a in build.architectures:
-            self.assertIn(a.code, response.data.decode())
+            self.assertIn(a.code, response_data)
         self.assertIn(
             build.version.displaynames["enu"].displayname,
-            response.data.decode(),
+            response_data,
         )
         self.assertIn(
             build.version.descriptions["enu"].description,
-            response.data.decode(),
+            response_data,
         )
-        self.assertIn("beta", response.data.decode())
+        self.assertIn("beta", response_data)
+        self.assertIn("label label-default", response_data)
+        self.assertIn("Inactive: Manual installation only.", response_data)
 
     def test_get_no_package(self):
         response = self.client.get(url_for("frontend.package", name="no-package"))

--- a/spkrepo/tests/test_frontend.py
+++ b/spkrepo/tests/test_frontend.py
@@ -28,7 +28,7 @@ class IndexTestCase(BaseTestCase):
 class PackagesTestCase(BaseTestCase):
     # Assert beta is not shown on Packages page
     def test_get_active_not_stable(self):
-        build = BuildFactory(version__report_url=None, active=True)
+        build = BuildFactory(active=True)
         db.session.commit()
         response = self.client.get(url_for("frontend.packages"))
         self.assert200(response)

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -290,7 +290,7 @@ class VersionView(ModelView):
         ("upgrade_wizard", "upgrade_wizard"),
         ("startable", "startable"),
     )
-
+    # TODO: Add beta and all_builds_active with Flask-Admin>1.0.8
     column_default_sort = (Version.insert_date, True)
 
     # Custom queries
@@ -533,7 +533,7 @@ class BuildView(ModelView):
         ("insert_date", "insert_date"),
         ("active", "active"),
     )
-
+    # TODO: Add version.package with Flask-Admin>1.0.8
     column_default_sort = (Build.insert_date, True)
 
     # Custom queries

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -290,7 +290,7 @@ class VersionView(ModelView):
         ("upgrade_wizard", "upgrade_wizard"),
         ("startable", "startable"),
     )
-    # TODO: Add beta and all_builds_active with Flask-Admin>1.0.8
+
     column_default_sort = (Version.insert_date, True)
 
     # Custom queries
@@ -533,7 +533,7 @@ class BuildView(ModelView):
         ("insert_date", "insert_date"),
         ("active", "active"),
     )
-    # TODO: Add version.package with Flask-Admin>1.0.8
+
     column_default_sort = (Build.insert_date, True)
 
     # Custom queries

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -64,12 +64,12 @@ def profile():
 
 @frontend.route("/packages")
 def packages():
+    # show only packages with at least one version, but ignore whether builds are active
     latest_version = (
         db.session.query(
             Version.package_id, db.func.max(Version.version).label("latest_version")
         )
         .join(Build)
-        .filter(Build.active)
         .group_by(Version.package_id)
         .subquery()
     )
@@ -96,7 +96,6 @@ def packages():
 
 @frontend.route("/package/<name>")
 def package(name):
-    # TODO: show only packages with at least a version and an active build
     package = Package.query.filter_by(name=name).first()
     if package is None:
         abort(404)

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -97,7 +97,7 @@ def packages():
 @frontend.route("/package/<name>")
 def package(name):
     package = Package.query.filter_by(name=name).first()
-    if package is None:
+    if package is None or not package.versions:
         abort(404)
     return render_template("frontend/package.html", package=package)
 


### PR DESCRIPTION
## Some web ui improvements

###  fix beta label and use different labels for active and inactive packages

- apply "beta" to package versions instead of packages
- use green labels for active packages
- use default (gray) label for inactive packages and add tooltip telling the package is inactive
- update version date (cut microseconds)
- fix unclosed span tag in package.html

###  show packages without active versions (leftover of #106)

- do not hide package in packages when there is no active version (https://github.com/SynoCommunity/spksrc/issues/5803)
- ~remove obsolete TODOs~

### fix webpage footer (fixes #116)
- correct link for SynoCommunity members