### PR TITLE
Replace per-request download tracking with CDN-level aggregated stats

### DIFF
--- a/migrations/versions/23bbd5c74cd0_replace_download_with_download_stat.py
+++ b/migrations/versions/23bbd5c74cd0_replace_download_with_download_stat.py
@@ -1,0 +1,138 @@
+"""Replace download with download_stat
+
+Revision ID: 23bbd5c74cd0
+Revises: 02a2b583dfae
+Create Date: 2026-06-03 23:26:45.582364
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "23bbd5c74cd0"
+down_revision: Union[str, Sequence[str], None] = "02a2b583dfae"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "download_stat",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("package_id", sa.Integer(), nullable=False),
+        sa.Column("build_id", sa.Integer(), nullable=True),
+        sa.Column("architecture_id", sa.Integer(), nullable=False),
+        sa.Column("firmware_build", sa.Integer(), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("count", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["architecture_id"],
+            ["architecture.id"],
+        ),
+        sa.ForeignKeyConstraint(["build_id"], ["build.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["package_id"],
+            ["package.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "package_id",
+            "architecture_id",
+            "firmware_build",
+            "date",
+            name="uq_download_stat",
+        ),
+    )
+    op.create_index(
+        op.f("ix_download_stat_architecture_id"),
+        "download_stat",
+        ["architecture_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_download_stat_build_id"), "download_stat", ["build_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_download_stat_date"), "download_stat", ["date"], unique=False
+    )
+    op.create_index(
+        op.f("ix_download_stat_firmware_build"),
+        "download_stat",
+        ["firmware_build"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_download_stat_package_id"),
+        "download_stat",
+        ["package_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_download_stat_package_id_date",
+        "download_stat",
+        ["package_id", "date"],
+        unique=False,
+    )
+    op.drop_index(op.f("ix_download_architecture_id"), table_name="download")
+    op.drop_index(op.f("ix_download_build_id"), table_name="download")
+    op.drop_index(op.f("ix_download_date"), table_name="download")
+    op.drop_table("download")
+    op.create_index(
+        op.f("ix_version_package_id"), "version", ["package_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Note: the restored 'download' table is structurally correct but the
+    corresponding Download model and nas.download route no longer exist
+    in the codebase. Downgrading will restore the schema but the application
+    will not function correctly without reverting the associated code changes.
+    """
+    op.drop_index(op.f("ix_version_package_id"), table_name="version")
+    op.create_table(
+        "download",
+        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column("build_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("architecture_id", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column("firmware_build", sa.INTEGER(), autoincrement=False, nullable=False),
+        sa.Column(
+            "ip_address", sa.VARCHAR(length=46), autoincrement=False, nullable=False
+        ),
+        sa.Column(
+            "user_agent", sa.VARCHAR(length=255), autoincrement=False, nullable=True
+        ),
+        sa.Column("date", postgresql.TIMESTAMP(), autoincrement=False, nullable=False),
+        sa.ForeignKeyConstraint(
+            ["architecture_id"],
+            ["architecture.id"],
+            name=op.f("download_architecture_id_fkey"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["build_id"], ["build.id"], name=op.f("download_build_id_fkey")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("download_pkey")),
+    )
+    op.create_index(op.f("ix_download_date"), "download", ["date"], unique=False)
+    op.create_index(
+        op.f("ix_download_build_id"), "download", ["build_id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_download_architecture_id"),
+        "download",
+        ["architecture_id"],
+        unique=False,
+    )
+    op.drop_index("ix_download_stat_package_id_date", table_name="download_stat")
+    op.drop_index(op.f("ix_download_stat_package_id"), table_name="download_stat")
+    op.drop_index(op.f("ix_download_stat_firmware_build"), table_name="download_stat")
+    op.drop_index(op.f("ix_download_stat_date"), table_name="download_stat")
+    op.drop_index(op.f("ix_download_stat_build_id"), table_name="download_stat")
+    op.drop_index(op.f("ix_download_stat_architecture_id"), table_name="download_stat")
+    op.drop_table("download_stat")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "alembic>=1.17.2",
     "bcrypt>=5.0.0",
+    "boto3>=1.34",
     "click>=8.3.1",
     "configparser>=7.2.0",
     "flask>=3.1.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -88,6 +88,16 @@ blinker==1.9.0 \
     #   flask
     #   flask-mail
     #   flask-principal
+boto3==1.43.22 \
+    --hash=sha256:0597fb9fe1613e636ac55219a5a54ad0fcb7c15e6be32c799301f7fb53ff04e1 \
+    --hash=sha256:2a7fe12d8e0731bb8aa7c1e59b4ccc770fda031b8659c2f6f497393bdcec3051
+    # via spkrepo
+botocore==1.43.22 \
+    --hash=sha256:b00de525e538289ed4a7a85263f1be4e47473c124cec87be6b23be49356bf745 \
+    --hash=sha256:ceec9f81d0891abe7b28ca2b2ee47e32de7b3360ad11e80d351470f015217379
+    # via
+    #   boto3
+    #   s3transfer
 cachelib==0.14.0 \
     --hash=sha256:4671000b032baa8fac47ad19850f4f522785cee764b4e04c5cfe8955a18d67de \
     --hash=sha256:73fedcadd0ba818fb2bb9f3c7cd5fcc2a71e86286f1842f55f28d500faee17f1
@@ -383,6 +393,12 @@ jinja2==3.1.6 \
     #   flask-admin
     #   flask-babel
     #   sphinx
+jmespath==1.1.0 \
+    --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
+    --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64
+    # via
+    #   boto3
+    #   botocore
 libpass==1.9.3 \
     --hash=sha256:3cbeb14d22086660e92c30d787ea981973d67394e81c8c870e1a83cfe1c84353 \
     --hash=sha256:7830b9323d9ba96a841ad698a8dec1d43a2b0b7f1c855c76772e7972c1c6d959
@@ -634,6 +650,10 @@ pygments==2.20.0 \
 pytest==9.0.3 \
     --hash=sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9 \
     --hash=sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c
+python-dateutil==2.9.0.post0 \
+    --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
+    --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+    # via botocore
 python-discovery==1.4.0 \
     --hash=sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da \
     --hash=sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3
@@ -699,13 +719,19 @@ roman-numerals==4.1.0 \
     --hash=sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2 \
     --hash=sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7
     # via sphinx
+s3transfer==0.18.0 \
+    --hash=sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6 \
+    --hash=sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd
+    # via boto3
 setuptools==82.0.1 \
     --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
     --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
-    # via flask-restful
+    # via
+    #   flask-restful
+    #   python-dateutil
 snowballstemmer==3.1.0 \
     --hash=sha256:17e6d1da216aa07db6dad37139ea70cf13c4b2e9a096f6e64a9648fc657d3154 \
     --hash=sha256:fd9e34526b23340cd23ffea6c9f9760974ecc2c2ac9e1d81401443ccdb2a801f
@@ -795,7 +821,9 @@ tzdata==2026.2 ; sys_platform == 'win32' \
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
-    # via requests
+    # via
+    #   botocore
+    #   requests
 virtualenv==21.4.1 \
     --hash=sha256:2ca543c713b72840ceffd94e9bdedfbd09a661defa1f7f69e5429ad4059442e2 \
     --hash=sha256:caf4ff72d1b4039057f41d8e8466e859513d67c0400d9c6b62c02c9d1ebc3e12

--- a/spkrepo/app.py
+++ b/spkrepo/app.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+import logging
+import sys
+
 import jinja2
 from flask import Flask
 from flask_admin import Admin
@@ -28,6 +31,20 @@ from .views import (
 def create_app(config=None, register_blueprints=True, init_admin=True):
     """Create a Flask app."""
     app = Flask("spkrepo")
+
+    # Logging setup
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    handler.setFormatter(formatter)
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    # Avoid duplicate handlers if reloaded
+    if not root.handlers:
+        root.addHandler(handler)
+    logging.getLogger("werkzeug").setLevel(logging.WARNING)
+    logging.getLogger("boto3").setLevel(logging.WARNING)
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
 
     # Configuration
     app.config.from_object(default_config)

--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -251,3 +251,216 @@ def clean():
         for name in dirs:
             os.rmdir(os.path.join(root, name))
     click.echo("Done")
+
+
+@spkrepo.command("ingest_logs")
+@with_appcontext
+def ingest_logs():
+    """Ingest download stats from Object Storage log files."""
+    import gzip
+    import json
+    import logging
+    import re
+    from collections import defaultdict
+    from datetime import date, datetime
+
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+    from flask import current_app
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from .models import Architecture, Build, DownloadStat, Version
+
+    logger = logging.getLogger(__name__)
+
+    def is_countable_download(record):
+        url = record.get("url", "")
+        path = url.split("?")[0]
+        if not path.endswith(".spk"):
+            return False
+        status = record.get("response_status")
+        if status == 200:
+            return True
+        if status == 206:
+            range_header = record.get("range", "")
+            return range_header == "" or range_header.startswith("bytes=0-")
+        return False
+
+    def parse_download(record):
+        url = record.get("url", "")
+        path = url.split("?")[0]
+        match = re.match(r"^/([^/]+)/([^/]+)/", path)
+        if not match:
+            return None
+        package_name = match.group(1)
+        try:
+            version_number = int(match.group(2))
+        except ValueError:
+            return None
+        arch_code = record.get("arch") or None
+        firmware_build = record.get("build") or None
+        if firmware_build is not None:
+            try:
+                firmware_build = int(firmware_build)
+            except ValueError:
+                firmware_build = None
+        try:
+            record_date = datetime.fromisoformat(record["timestamp"]).date()
+        except (KeyError, ValueError):
+            record_date = date.today()
+        return package_name, version_number, arch_code, firmware_build, record_date
+
+    bucket = current_app.config["OBJECT_STORAGE_BUCKET"]
+    prefix = current_app.config.get("OBJECT_STORAGE_PREFIX", "logs/")
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=current_app.config["OBJECT_STORAGE_ENDPOINT"],
+        aws_access_key_id=current_app.config["OBJECT_STORAGE_ACCESS_KEY"],
+        aws_secret_access_key=current_app.config["OBJECT_STORAGE_SECRET_KEY"],
+        region_name=current_app.config.get("OBJECT_STORAGE_REGION", "us-east"),
+    )
+
+    try:
+        response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    except (BotoCoreError, ClientError) as e:
+        logger.error("Failed to list objects in bucket: %s", e)
+        return
+
+    objects = response.get("Contents", [])
+    if not objects:
+        logger.info("No log files to process.")
+        return
+
+    logger.info("Processing %d log file(s).", len(objects))
+
+    build_cache = {}  # (package_name, version_number) -> (build_id, package_id) or None
+    arch_cache = {}  # arch_code -> architecture_id or None
+    counts = defaultdict(int)
+    build_ids = {}  # agg_key -> build_id or None
+    processed_keys = []
+
+    skipped_no_arch = 0
+    skipped_no_build = 0
+    skipped_no_arch_id = 0
+
+    for obj in objects:
+        key = obj["Key"]
+        try:
+            body = s3.get_object(Bucket=bucket, Key=key)["Body"]
+            lines = gzip.open(body, "rt") if key.endswith(".gz") else body.iter_lines()
+
+            for raw_line in lines:
+                if isinstance(raw_line, bytes):
+                    raw_line = raw_line.decode("utf-8")
+                raw_line = raw_line.strip()
+                if not raw_line:
+                    continue
+                try:
+                    record = json.loads(raw_line)
+                except json.JSONDecodeError:
+                    continue
+                if not is_countable_download(record):
+                    continue
+                parsed = parse_download(record)
+                if parsed is None:
+                    continue
+                package_name, version_number, arch_code, firmware_build, record_date = (
+                    parsed
+                )
+
+                # Skip records with missing arch or firmware
+                if arch_code is None or firmware_build is None:
+                    skipped_no_arch += 1
+                    continue
+
+                # Resolve build_id and package_id
+                cache_key = (package_name, version_number)
+                if cache_key not in build_cache:
+                    build = (
+                        db.session.query(Build)
+                        .join(Version)
+                        .filter(
+                            Version.version == version_number,
+                            Version.package.has(name=package_name),
+                        )
+                        .first()
+                    )
+                    if build:
+                        build_cache[cache_key] = (build.id, build.version.package_id)
+                    else:
+                        build_cache[cache_key] = None
+
+                cached = build_cache[cache_key]
+                if cached is None:
+                    skipped_no_build += 1
+                    continue
+                build_id, package_id = cached
+
+                # Resolve architecture_id
+                if arch_code not in arch_cache:
+                    arch = Architecture.find(arch_code, syno=True)
+                    arch_cache[arch_code] = arch.id if arch else None
+                architecture_id = arch_cache[arch_code]
+
+                if architecture_id is None:
+                    skipped_no_arch_id += 1
+                    continue
+
+                # Aggregate
+                agg_key = (package_id, architecture_id, firmware_build, record_date)
+                counts[agg_key] += 1
+
+                # Track build_id for analytics — set None if ambiguous
+                if agg_key not in build_ids:
+                    build_ids[agg_key] = build_id
+                elif build_ids[agg_key] != build_id:
+                    build_ids[agg_key] = None
+
+            processed_keys.append(key)
+
+        except (BotoCoreError, ClientError) as e:
+            logger.error("Failed to read %s: %s", key, e)
+            continue
+
+    if counts:
+        rows = [
+            {
+                "package_id": package_id,
+                "build_id": build_ids.get(agg_key),
+                "architecture_id": architecture_id,
+                "firmware_build": firmware_build,
+                "date": record_date,
+                "count": count,
+            }
+            for agg_key, count in counts.items()
+            for (package_id, architecture_id, firmware_build, record_date) in [agg_key]
+        ]
+        try:
+            stmt = pg_insert(DownloadStat).values(rows)
+            stmt = stmt.on_conflict_do_update(
+                constraint="uq_download_stat",
+                set_={"count": DownloadStat.count + stmt.excluded.count},
+            )
+            db.session.execute(stmt)
+            db.session.commit()
+        except Exception as e:
+            logger.error("Failed to upsert download stats: %s", e)
+            return
+
+    for key in processed_keys:
+        try:
+            s3.delete_object(Bucket=bucket, Key=key)
+        except (BotoCoreError, ClientError) as e:
+            logger.warning("Failed to delete %s: %s", key, e)
+
+    logger.info(
+        "Ingested %d download events from %d file(s). "
+        "Skipped — missing arch/firmware: %d, "
+        "unknown package/version: %d, unknown architecture: %d.",
+        sum(counts.values()),
+        len(processed_keys),
+        skipped_no_arch,
+        skipped_no_build,
+        skipped_no_arch_id,
+    )

--- a/spkrepo/config.py
+++ b/spkrepo/config.py
@@ -16,6 +16,14 @@ GNUPG_TIMESTAMP_URL = "http://timestamp.synology.com/timestamp.php"
 GNUPG_PATH = None
 GNUPG_FINGERPRINT = "gnupg-fingerprint"
 
+# Object Storage (S3-compatible)
+OBJECT_STORAGE_ENDPOINT = "https://us-east.object.fastlystorage.app"
+OBJECT_STORAGE_REGION = "us-east"
+OBJECT_STORAGE_BUCKET = "your-log-bucket"
+OBJECT_STORAGE_PREFIX = "logs/"
+OBJECT_STORAGE_ACCESS_KEY = "your-read-key"
+OBJECT_STORAGE_SECRET_KEY = "your-read-secret"
+
 # Security
 SECURITY_CONFIRMABLE = True
 SECURITY_REGISTERABLE = True

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -30,7 +30,7 @@ package_user_maintainer = db.Table(
 
 
 class _days_ago(FunctionElement):
-    """Dialect-aware SQL expression for a timestamp N days in the past."""
+    """Dialect-aware SQL expression for a date N days in the past."""
 
     inherit_cache = True
 
@@ -41,17 +41,17 @@ class _days_ago(FunctionElement):
 
 @compiles(_days_ago, "sqlite")
 def _compile_days_ago_sqlite(element, compiler, **kw):
-    return f"datetime(CURRENT_TIMESTAMP, '-{element.days} days')"
+    return f"date('now', '-{element.days} days')"
 
 
 @compiles(_days_ago, "postgresql")
 def _compile_days_ago_postgresql(element, compiler, **kw):
-    return f"NOW() - INTERVAL '{element.days} days'"
+    return f"CURRENT_DATE - INTERVAL '{element.days} days'"
 
 
 @compiles(_days_ago)
 def _compile_days_ago_default(element, compiler, **kw):
-    return f"datetime(CURRENT_TIMESTAMP, '-{element.days} days')"
+    return f"date('now', '-{element.days} days')"
 
 
 # Architecture code mappings — module-level constants, not instance data
@@ -342,31 +342,49 @@ version_service_dependency = db.Table(
 )
 
 
-class Download(db.Model):
-    __tablename__ = "download"
+class DownloadStat(db.Model):
+    __tablename__ = "download_stat"
 
     # Columns
     id = db.Column(db.Integer, primary_key=True)
+    package_id = db.Column(
+        db.Integer, db.ForeignKey("package.id"), nullable=False, index=True
+    )
     build_id = db.Column(
-        db.Integer, db.ForeignKey("build.id"), nullable=False, index=True
+        db.Integer,
+        db.ForeignKey("build.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
     )
     architecture_id = db.Column(
         db.Integer, db.ForeignKey("architecture.id"), nullable=False, index=True
     )
-    firmware_build = db.Column(db.Integer, nullable=False)
-    ip_address = db.Column(db.Unicode(46), nullable=False)
-    user_agent = db.Column(db.Unicode(255))
-    date = db.Column(db.DateTime, default=_utcnow, nullable=False, index=True)
+    firmware_build = db.Column(db.Integer, nullable=False, index=True)
+    date = db.Column(db.Date, nullable=False, index=True)
+    count = db.Column(db.Integer, nullable=False, default=0)
+
+    # Constraints
+    __table_args__ = (
+        db.UniqueConstraint(
+            "package_id",
+            "architecture_id",
+            "firmware_build",
+            "date",
+            name="uq_download_stat",
+        ),
+        db.Index("ix_download_stat_package_id_date", "package_id", "date"),
+    )
 
     # Relationships
-    build = db.relationship("Build", back_populates="downloads")
+    package = db.relationship("Package", back_populates="download_stats")
+    build = db.relationship("Build", back_populates="download_stats")
     architecture = db.relationship("Architecture")
 
-    def __str__(self):
-        return self.ip_address
-
     def __repr__(self):
-        return f"<{self.__class__.__name__} {self.ip_address}>"
+        return (
+            f"<{self.__class__.__name__} package={self.package_id} "
+            f"date={self.date} count={self.count}>"
+        )
 
 
 build_architecture = db.Table(
@@ -418,10 +436,11 @@ class Build(db.Model):
         lazy=False,
     )
     publisher = db.relationship("User", foreign_keys=[publisher_user_id])
-    downloads = db.relationship(
-        "Download",
+    download_stats = db.relationship(
+        "DownloadStat",
         back_populates="build",
-        cascade="save-update, merge, delete, delete-orphan",
+        cascade="save-update, merge",
+        passive_deletes=True,
     )
     buildmanifest = db.relationship(
         "BuildManifest",
@@ -515,7 +534,9 @@ class Version(db.Model):
 
     # Columns
     id = db.Column(db.Integer, primary_key=True)
-    package_id = db.Column(db.Integer, db.ForeignKey("package.id"), nullable=False)
+    package_id = db.Column(
+        db.Integer, db.ForeignKey("package.id"), nullable=False, index=True
+    )
     version = db.Column(db.Integer, nullable=False, index=True)
     upstream_version = db.Column(db.Unicode(20), nullable=False)
     changelog = db.Column(db.UnicodeText)
@@ -636,22 +657,19 @@ class Package(db.Model):
     name = db.Column(db.Unicode(50), nullable=False)
     insert_date = db.Column(db.DateTime, default=_utcnow, nullable=False)
     download_count = db.column_property(
-        db.select(db.func.count(Download.id))
-        .select_from(Download.__table__.join(Build).join(Version))
-        .where(Version.package_id == id)
+        db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+        .where(DownloadStat.package_id == id)
         .scalar_subquery(),
         deferred=True,
     )
     recent_download_count = db.column_property(
-        db.select(db.func.count(Download.id))
-        .select_from(Download.__table__.join(Build).join(Version))
+        db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
         .where(
             db.and_(
-                Version.package_id == id,
-                Download.date >= _days_ago(90),
+                DownloadStat.package_id == id,
+                DownloadStat.date >= _days_ago(90),
             )
         )
-        .correlate_except(Download)
         .scalar_subquery(),
         deferred=True,
     )
@@ -672,6 +690,11 @@ class Package(db.Model):
         "User",
         secondary="package_user_maintainer",
         back_populates="maintained_packages",
+    )
+    download_stats = db.relationship(
+        "DownloadStat",
+        back_populates="package",
+        cascade="all, delete-orphan",
     )
 
     # Constraints

--- a/spkrepo/tests/common.py
+++ b/spkrepo/tests/common.py
@@ -31,7 +31,7 @@ from spkrepo.models import (
     BuildManifest,
     Description,
     DisplayName,
-    Download,
+    DownloadStat,
     Firmware,
     Icon,
     Language,
@@ -327,19 +327,19 @@ class BuildFactory(SQLAlchemyModelFactory):
         return super(BuildFactory, cls).create_batch(size, **kwargs)
 
 
-class DownloadFactory(SQLAlchemyModelFactory):
+class DownloadStatFactory(SQLAlchemyModelFactory):
     class Meta:
         sqlalchemy_session = db.session
-        model = Download
+        model = DownloadStat
 
+    package = factory.LazyAttribute(lambda x: x.build.version.package)
     build = factory.SubFactory(BuildFactory)
     architecture = factory.LazyAttribute(lambda x: x.build.architectures[0])
     firmware_build = factory.LazyAttribute(
         lambda x: random.choice([f.build for f in Firmware.query.all()])
     )
-    ip_address = factory.LazyAttribute(lambda x: fake.ipv4())
-    user_agent = factory.LazyAttribute(lambda x: fake.user_agent())
-    date = factory.LazyAttribute(lambda x: fake.date_time_this_month())
+    date = factory.LazyAttribute(lambda x: fake.date_this_month())
+    count = factory.LazyAttribute(lambda x: random.randint(1, 1000))
 
 
 class BaseTestCase(TestCase):

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 import hashlib
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 from flask import url_for
 
 from spkrepo.ext import db
-from spkrepo.models import Architecture, Download, Firmware
+from spkrepo.models import Architecture, Firmware
 from spkrepo.tests.common import (
     BaseTestCase,
     BuildFactory,
-    DownloadFactory,
+    DownloadStatFactory,
     PackageFactory,
 )
 
@@ -264,12 +264,23 @@ class CatalogTestCase(BaseTestCase):
             architectures=[Architecture.find("cedarview")],
             firmware_min=Firmware.find(1594),
         )
-        DownloadFactory.create_batch(1, build=build, date=datetime.now())
-        DownloadFactory.create_batch(
-            2, build=build, date=datetime.now() - timedelta(days=30)
+        DownloadStatFactory(
+            package=package,
+            build=build,
+            date=datetime.now().date(),
+            count=1,
         )
-        DownloadFactory.create_batch(
-            4, build=build, date=datetime.now() - timedelta(days=100)
+        DownloadStatFactory(
+            package=package,
+            build=build,
+            date=(datetime.now() - timedelta(days=30)).date(),
+            count=2,
+        )
+        DownloadStatFactory(
+            package=package,
+            build=build,
+            date=(datetime.now() - timedelta(days=100)).date(),
+            count=4,
         )
         db.session.commit()
         data = dict(arch="cedarview", build="1594", language="enu")
@@ -614,166 +625,3 @@ class CatalogTestCase(BaseTestCase):
         self.assertEqual(entry["report_url"], build.version.report_url)
         self.assertIn("beta", entry)
         self.assertTrue(entry["beta"])
-
-
-class DownloadTestCase(BaseTestCase):
-    def test_generic(self):
-        architecture = Architecture.find("88f6281", syno=True)
-        build = BuildFactory(
-            active=True,
-            version__report_url=None,
-            architectures=[architecture],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        self.assertEqual(Download.query.count(), 0)
-        response = self.client.get(
-            url_for(
-                "nas.download",
-                architecture_id=architecture.id,
-                firmware_build=4458,
-                build_id=build.id,
-            ),
-            environ_base={"REMOTE_ADDR": "127.0.0.1"},
-            headers={"User-Agent": "My User Agent"},
-        )
-        self.assert302(response)
-        self.assertEqual(Download.query.count(), 1)
-        download = Download.query.first()
-        self.assertEqual(download.ip_address, "127.0.0.1")
-        self.assertEqual(download.user_agent, "My User Agent")
-        self.assertEqual(download.firmware_build, 4458)
-        self.assertAlmostEqual(
-            download.date,
-            datetime.now(timezone.utc).replace(microsecond=0, tzinfo=None),
-            delta=timedelta(seconds=10),
-        )
-
-    def test_wrong_build(self):
-        architecture = Architecture.find("88f6281", syno=True)
-        build = BuildFactory(
-            active=False,
-            version__report_url=None,
-            architectures=[architecture],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        self.assertEqual(Download.query.count(), 0)
-        response = self.client.get(
-            url_for(
-                "nas.download",
-                architecture_id=architecture.id,
-                firmware_build=4458,
-                build_id=build.id + 1,
-            )
-        )
-        self.assert404(response)
-        self.assertEqual(Download.query.count(), 0)
-
-    def test_inactive_build(self):
-        architecture = Architecture.find("88f6281", syno=True)
-        build = BuildFactory(
-            active=False,
-            version__report_url=None,
-            architectures=[architecture],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        self.assertEqual(Download.query.count(), 0)
-        response = self.client.get(
-            url_for(
-                "nas.download",
-                architecture_id=architecture.id,
-                firmware_build=4458,
-                build_id=build.id,
-            )
-        )
-        self.assert403(response)
-        self.assertEqual(Download.query.count(), 0)
-
-    def test_wrong_architecture(self):
-        architecture = Architecture.find("88f6281", syno=True)
-        build = BuildFactory(
-            active=True,
-            version__report_url=None,
-            architectures=[architecture],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        self.assertEqual(Download.query.count(), 0)
-        response = self.client.get(
-            url_for(
-                "nas.download",
-                architecture_id=10,
-                firmware_build=4458,
-                build_id=build.id,
-            )
-        )
-        self.assert404(response)
-        self.assertEqual(Download.query.count(), 0)
-
-    def test_incorrect_architecture(self):
-        architecture = Architecture.find("88f6281", syno=True)
-        build = BuildFactory(
-            active=True,
-            version__report_url=None,
-            architectures=[architecture],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        self.assertEqual(Download.query.count(), 0)
-        response = self.client.get(
-            url_for(
-                "nas.download",
-                architecture_id=Architecture.find("cedarview").id,
-                firmware_build=4458,
-                build_id=build.id,
-            )
-        )
-        self.assert400(response)
-        self.assertEqual(Download.query.count(), 0)
-
-    def test_incorrect_firmware_build(self):
-        architecture = Architecture.find("88f6281", syno=True)
-        build = BuildFactory(
-            active=True,
-            version__report_url=None,
-            architectures=[architecture],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        self.assertEqual(Download.query.count(), 0)
-        response = self.client.get(
-            url_for(
-                "nas.download",
-                architecture_id=architecture.id,
-                firmware_build=1593,
-                build_id=build.id,
-            )
-        )
-        self.assert400(response)
-        self.assertEqual(Download.query.count(), 0)
-
-    def test_firmware_build_above_firmware_max(self):
-        architecture = Architecture.find("88f6281", syno=True)
-        firmware_min = Firmware.find(1594)
-        firmware_max = Firmware.find(4458)
-        build = BuildFactory(
-            active=True,
-            version__report_url=None,
-            architectures=[architecture],
-            firmware_min=firmware_min,
-            firmware_max=firmware_max,
-        )
-        db.session.commit()
-        self.assertEqual(Download.query.count(), 0)
-        response = self.client.get(
-            url_for(
-                "nas.download",
-                architecture_id=architecture.id,
-                firmware_build=firmware_max.build + 1,
-                build_id=build.id,
-            )
-        )
-        self.assert400(response)
-        self.assertEqual(Download.query.count(), 0)

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -6,7 +6,6 @@ from flask import (
     abort,
     current_app,
     json,
-    redirect,
     request,
     send_from_directory,
     url_for,
@@ -19,7 +18,6 @@ from ..models import (
     Build,
     Description,
     DisplayName,
-    Download,
     Firmware,
     Language,
     Package,
@@ -277,36 +275,6 @@ def catalog():
 
     result = get_catalog(arch, build, major, language, beta)
     return Response(json.dumps(result), mimetype="application/json")
-
-
-@nas.route("/download/<int:architecture_id>/<int:firmware_build>/<int:build_id>")
-def download(architecture_id, firmware_build, build_id):
-    build = db.get_or_404(Build, build_id)
-    if not build.active:
-        abort(403)
-
-    architecture = db.get_or_404(Architecture, architecture_id)
-
-    if (
-        architecture not in build.architectures
-        or firmware_build < build.firmware_min.build
-        or (
-            build.firmware_max is not None and firmware_build > build.firmware_max.build
-        )
-    ):
-        abort(400)
-
-    dl = Download(
-        build=build,
-        architecture=architecture,
-        firmware_build=firmware_build,
-        ip_address=request.remote_addr,
-        user_agent=request.user_agent.string,
-    )
-    db.session.add(dl)
-    db.session.commit()
-
-    return redirect(url_for(".data", path=build.path))
 
 
 @nas.route("/<path:path>")

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -108,13 +108,21 @@ def get_catalog(arch, build, major, language, beta):
         .subquery()
     )
 
-    # Step 3: Get the latest builds for versions
+    # Step 3: Get the latest builds for versions, undefer download counts
+    # so they are computed once and included in the cache rather than
+    # firing a correlated subquery per package on every cache hit.
     firmware_min_for_build = aliased(Firmware)
     latest_build = (
         Build.query.options(
             db.joinedload(Build.architectures),
             db.joinedload(Build.firmware_min),
             db.joinedload(Build.firmware_max),
+            db.joinedload(Build.version)
+            .joinedload(Version.package)
+            .undefer(Package.download_count),
+            db.joinedload(Build.version)
+            .joinedload(Version.package)
+            .undefer(Package.recent_download_count),
             db.joinedload(Build.version).joinedload(Version.package),
             db.joinedload(Build.version).joinedload(Version.service_dependencies),
             db.joinedload(Build.version).joinedload(Version.icons),

--- a/uv.lock
+++ b/uv.lock
@@ -119,6 +119,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/31/32388d5ec332ffe81d8f3650860f94b66294009172d188c390cad58c6f5f/boto3-1.43.22.tar.gz", hash = "sha256:2a7fe12d8e0731bb8aa7c1e59b4ccc770fda031b8659c2f6f497393bdcec3051", size = 113203, upload-time = "2026-06-03T19:33:13.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/6b/c2fb3b91e849882df5426e68cc15eb2b5ba6ac28325ab2aa3a1065da5884/boto3-1.43.22-py3-none-any.whl", hash = "sha256:0597fb9fe1613e636ac55219a5a54ad0fcb7c15e6be32c799301f7fb53ff04e1", size = 140536, upload-time = "2026-06-03T19:33:10.939Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/cf/840f1b8db16d45e3807c23d1ea779723eed1cd9cf3b6c49e16f372d2a777/botocore-1.43.22.tar.gz", hash = "sha256:b00de525e538289ed4a7a85263f1be4e47473c124cec87be6b23be49356bf745", size = 15458781, upload-time = "2026-06-03T19:33:02.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/6b/576a1b0f915871e35f14a33104f2bcae635f19c6a72486ba639db0d1fc70/botocore-1.43.22-py3-none-any.whl", hash = "sha256:ceec9f81d0891abe7b28ca2b2ee47e32de7b3360ad11e80d351470f015217379", size = 15141375, upload-time = "2026-06-03T19:32:58.324Z" },
+]
+
+[[package]]
 name = "cachelib"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -639,6 +667,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "libpass"
 version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
@@ -969,6 +1006,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1067,6 +1116,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
 ]
 
 [[package]]
@@ -1211,6 +1272,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "bcrypt" },
+    { name = "boto3" },
     { name = "click" },
     { name = "configparser" },
     { name = "flask" },
@@ -1251,6 +1313,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.17.2" },
     { name = "bcrypt", specifier = ">=5.0.0" },
+    { name = "boto3", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "configparser", specifier = ">=7.2.0" },
     { name = "flask", specifier = ">=3.1.2" },


### PR DESCRIPTION
## Description

This PR replaces the unused per-request `Download` model with a new `DownloadStat` model that aggregates download counts from Fastly CDN log files, capturing 100% of downloads including the 97% served directly from cache that never reached the origin server.

**Changes:**

The `Download` model and associated `nas.download` route have been removed as they were never used and only captured origin hits. The new `DownloadStat` model aggregates counts by package, architecture, firmware version, and date, with `package_id` as the primary foreign key so stats survive build and version deletions while being cleaned up when a package is deleted.

A new `flask spkrepo ingest_logs` CLI command reads gzip-compressed JSON log files from an S3-compatible object storage bucket (configured via `OBJECT_STORAGE_*` config vars), aggregates download events, bulk-upserts counts into `download_stat`, and deletes processed files to keep storage usage minimal. The command runs in a dedicated `ingest` container on a 5-minute loop matching the Fastly log rotation period.

Stdout logging at INFO level has been added for visibility in container environments, with noisy loggers (Werkzeug, boto3, botocore, urllib3) suppressed to WARNING.

The existing `download_count` and `recent_download_count` properties on `Package` are preserved and continue to work transparently via the new model, so the catalog response and admin UI are unaffected.

**Configuration required:**
- Fastly Object Storage bucket and access key configured in `docker_config.py`
- Fastly VCL updated to capture `arch` and `build` parameters before query string is stripped from `.spk` requests
- `ingest` service added to `docker-compose.yml`
- `boto3` added to project dependencies
- Database migration must be run before deploying

Closes: #22