### PR TITLE
github build: Use apt-get rather than apt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           virtualenvs-in-project: true
       - name: Install ImageMagick
-        run: sudo apt install imagemagick
+        run: apt-get install -y imagemagick
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           virtualenvs-in-project: true
       - name: Install ImageMagick
-        run: apt-get install -y imagemagick
+        run: sudo apt-get install -y imagemagick
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v4


### PR DESCRIPTION
This is a follow-on from #138 to switch to apt-get and remove apt warnings.