### PR TITLE
Fix: Update beta logic and query to handle empty report_url

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -462,7 +462,7 @@ class Version(db.Model):
 
     @hybrid_property
     def beta(self):
-        return self.report_url != None  # noqa: E711
+        return bool(self.report_url)  # Treats None and "" as False
 
     @hybrid_property
     def all_builds_active(self):
@@ -483,6 +483,10 @@ class Version(db.Model):
             .where(Build.version_id == cls.id)
             .label("total_builds")
         )
+
+    @beta.expression
+    def beta(cls):
+        return db.and_(cls.report_url.isnot(None), cls.report_url != "")
 
     @property
     def path(self):

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -64,7 +64,9 @@ def get_catalog(arch, build, language, beta):
     ).select_from(Version)
 
     if not beta:
-        latest_version = latest_version.filter(Version.report_url.is_(None))
+        latest_version = latest_version.filter(
+            db.or_(Version.report_url.is_(None), Version.report_url == "")
+        )
 
     latest_version = (
         latest_version.join(Build)


### PR DESCRIPTION
- Updated the beta hybrid property in the Version model to treat both None and empty strings as non-beta.
- Modified the catalog query to include versions where report_url is either NULL or an empty string when beta=False.
- Ensured consistent behavior for beta builds in both Python and SQLAlchemy contexts.

Fixes: #140