### PR TITLE
Catalog: Optimize Querying and Restrict Beta Packages to DSM < 7.0

### DIFF
--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -132,8 +132,8 @@ def get_catalog(arch, build, major, language, beta):
 
     # Step 4: Construct response with "packages"
     packages = []
-    for b in latest_build.all():
-        packages.append(build_package_entry(b, language))
+    for b in latest_build:
+        packages.append(build_package_entry(b, language, arch, build))
 
     # DSM 5.1
     if build >= 5004:
@@ -152,7 +152,7 @@ def get_catalog(arch, build, major, language, beta):
     return packages
 
 
-def build_package_entry(b, language):
+def build_package_entry(b, language, arch, build):
     entry = {
         "package": b.version.package.name,
         "version": b.version.version_string,
@@ -165,8 +165,8 @@ def build_package_entry(b, language):
         "link": url_for(
             ".data",
             path=b.path,
-            arch=b.architectures[0].code,
-            build=b.firmware.build,
+            arch=arch,
+            build=build,
             _external=True,
         ),
         "thumbnail": [
@@ -247,7 +247,7 @@ def catalog():
     if build < 40000:
         beta = request.values.get("package_update_channel") == "beta"
     else:
-        beta = False
+        beta = False  # Ensure no beta packages are returned for DSM 7+
     # Check if "major" is provided
     if "major" in request.values:
         try:

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -243,7 +243,11 @@ def catalog():
         build = int(request.values["build"])
     except ValueError:
         abort(422)
-    beta = request.values.get("package_update_channel") == "beta"
+    # DSM 7.0
+    if build < 40000:
+        beta = request.values.get("package_update_channel") == "beta"
+    else:
+        beta = False
     # Check if "major" is provided
     if "major" in request.values:
         try:


### PR DESCRIPTION
## Description

This PR improves catalog generation with optimizations and structural refinements:

- Use `major` from request when available to reduce queries against the `Firmware` table.
- Restrict beta package catalogs to DSM < 7.0 to align with existing constraints.
- Refactor catalog filling into a separate function for improved readability and maintainability.