### PR TITLE
Routing: Disable strict-slash matching for compatibility

### DIFF
--- a/spkrepo/app.py
+++ b/spkrepo/app.py
@@ -32,6 +32,7 @@ def create_app(config=None, register_blueprints=True, init_admin=True):
     # Configuration
     app.config.from_object(default_config)
     app.config.from_envvar("SPKREPO_CONFIG", silent=True)
+    app.url_map.strict_slashes = False
     if config is not None:
         app.config.from_object(config)
 


### PR DESCRIPTION
**Description:**
Werkzeug 2.2.3+ introduced stricter handling of trailing slashes in route definitions, causing requests to fail if the exact slash format isn't matched. This PR disables `strict_slashes` globally in the Flask app factory to restore the previous behavior of accepting routes with or without trailing slashes. This improves compatibility and reduces the likelihood of 404 errors due to minor route formatting differences.