### PR TITLE
Make Flask subdomain matching configurable via `SUBDOMAIN_MATCHING`

### DIFF
--- a/spkrepo/app.py
+++ b/spkrepo/app.py
@@ -34,8 +34,7 @@ def create_app(config=None, register_blueprints=True, init_admin=True):
     app.config.from_envvar("SPKREPO_CONFIG", silent=True)
 
     # Enable or disable Flask’s subdomain routing per config
-    sub_match = app.config.get("SUBDOMAIN_MATCHING", False)
-    app.url_map.subdomain_matching = sub_match
+    app.subdomain_matching = app.config.get("SUBDOMAIN_MATCHING", False)
 
     if config is not None:
         app.config.from_object(config)

--- a/spkrepo/app.py
+++ b/spkrepo/app.py
@@ -32,6 +32,11 @@ def create_app(config=None, register_blueprints=True, init_admin=True):
     # Configuration
     app.config.from_object(default_config)
     app.config.from_envvar("SPKREPO_CONFIG", silent=True)
+
+    # Enable or disable Flask’s subdomain routing per config
+    sub_match = app.config.get("SUBDOMAIN_MATCHING", False)
+    app.url_map.subdomain_matching = sub_match
+
     if config is not None:
         app.config.from_object(config)
 

--- a/spkrepo/config.py
+++ b/spkrepo/config.py
@@ -5,6 +5,8 @@ DEBUG = True
 TESTING = False
 SECRET_KEY = "secret-key"
 MAX_CONTENT_LENGTH = 170 * 1024 * 1024
+# Enable subdomain-based routing (False in local dev; True in prod)
+SUBDOMAIN_MATCHING = False
 
 # Application
 DATA_PATH = os.path.realpath("data")


### PR DESCRIPTION
**Background:**

In PR #142 we bumped Flask (2.3.3→3.1.0) and Werkzeug (3.0.1→3.1.3), which inadvertently disabled Flask’s default subdomain routing behavior. As a result, our blueprints registered with `subdomain="api"` and `subdomain="packages"` no longer matched incoming requests on those hosts, breaking key endpoints in production.

**What this PR does:**

* Adds a new `SUBDOMAIN_MATCHING` flag to **`config.py`**, defaulting to `False` for local development.
* In the Flask factory (`app.py`), reads `SUBDOMAIN_MATCHING` and sets `app.subdomain_matching` accordingly.

**Why this is required:**

* Restores blueprint routes on `api.<domain>` and `packages.<domain>` that stopped matching after the Flask/Werkzeug upgrade.
* Keeps local development flows intact (using `localhost`) without subdomains.

**Usage:**

* **Dev:** leave `SUBDOMAIN_MATCHING=False` in `config.py`.
* **Prod:** set `SUBDOMAIN_MATCHING=True` (via your production config) to re-enable subdomain‐based routing.

Fixes: #144