### PR TITLE
Make datetime calls timezone-aware in tests

### DIFF
--- a/spkrepo/tests/test_api.py
+++ b/spkrepo/tests/test_api.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import base64
-import datetime
 import os
+from datetime import datetime, timedelta, timezone
 
 from flask import current_app, url_for
 
@@ -33,8 +33,8 @@ class PackagesTestCase(BaseTestCase):
         self.assertEqual(inserted_build.extract_size, build.extract_size)
         self.assertAlmostEqual(
             inserted_build.insert_date,
-            datetime.datetime.utcnow().replace(microsecond=0),
-            delta=datetime.timedelta(seconds=10),
+            datetime.now(timezone.utc).replace(microsecond=0),
+            delta=timedelta(seconds=10),
         )
         self.assertFalse(inserted_build.active)
 

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import hashlib
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from flask import url_for
 
@@ -575,7 +575,7 @@ class DownloadTestCase(BaseTestCase):
         self.assertEqual(download.firmware_build, 4458)
         self.assertAlmostEqual(
             download.date,
-            datetime.utcnow().replace(microsecond=0),
+            datetime.now(timezone.utc).replace(microsecond=0),
             delta=timedelta(seconds=10),
         )
 


### PR DESCRIPTION
**Description**

* Replace all `datetime.utcnow().replace(microsecond=0)` calls with
  `datetime.now(timezone.utc).replace(microsecond=0)`
  in **test\_api.py** and **test\_nas.py**
* Update imports to use `import datetime` (referencing `datetime.timezone`)
* Removes DeprecationWarnings without altering test semantics (still allows a 10-second delta)
