### PR TITLE
Update API responses and Admin UI

### DIFF
--- a/migrations/versions/05cba02585a2_replace_extract_size_with_size_on_build.py
+++ b/migrations/versions/05cba02585a2_replace_extract_size_with_size_on_build.py
@@ -8,9 +8,8 @@ Create Date: 2026-04-22 04:21:22.505628
 
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "05cba02585a2"

--- a/migrations/versions/05cba02585a2_replace_extract_size_with_size_on_build.py
+++ b/migrations/versions/05cba02585a2_replace_extract_size_with_size_on_build.py
@@ -1,0 +1,34 @@
+"""Remove unused extract_size column and add size column to build table
+
+Revision ID: 05cba02585a2
+Revises: 30bc0c0455f8
+Create Date: 2026-04-22 04:21:22.505628
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "05cba02585a2"
+down_revision: Union[str, Sequence[str], None] = "30bc0c0455f8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("build", sa.Column("size", sa.Integer(), nullable=True))
+    op.drop_column("build", "extract_size")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "build",
+        sa.Column("extract_size", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.drop_column("build", "size")

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -7,8 +7,8 @@ import shutil
 from flask import current_app
 from flask_security import RoleMixin, SQLAlchemyUserDatastore, UserMixin
 from sqlalchemy import event, func, text
-from sqlalchemy.orm import Session
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import Session
 from sqlalchemy.orm.collections import attribute_mapped_collection
 
 from .ext import db
@@ -300,7 +300,9 @@ class Download(db.Model):
     firmware_build = db.Column(db.Integer, nullable=False)
     ip_address = db.Column(db.Unicode(46), nullable=False)
     user_agent = db.Column(db.Unicode(255))
-    date = db.Column(db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+    date = db.Column(
+        db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False
+    )
 
     # Relationships
     build = db.relationship("Build", back_populates="downloads")
@@ -335,7 +337,9 @@ class Build(db.Model):
     path = db.Column(db.Unicode(2048))
     md5 = db.Column(db.Unicode(32))
     size = db.Column(db.Integer)
-    insert_date = db.Column(db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+    insert_date = db.Column(
+        db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False
+    )
     active = db.Column(db.Boolean(), default=False, nullable=False)
 
     # Relationships
@@ -465,7 +469,9 @@ class Version(db.Model):
     upgrade_wizard = db.Column(db.Boolean)
     startable = db.Column(db.Boolean)
     license = db.Column(db.UnicodeText)
-    insert_date = db.Column(db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+    insert_date = db.Column(
+        db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False
+    )
 
     # Relationships
     package = db.relationship("Package", back_populates="versions", lazy=False)
@@ -563,7 +569,9 @@ class Package(db.Model):
         db.Integer, db.ForeignKey("user.id", ondelete="SET NULL")
     )
     name = db.Column(db.Unicode(50), nullable=False)
-    insert_date = db.Column(db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+    insert_date = db.Column(
+        db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False
+    )
     download_count = db.column_property(
         db.select(db.func.count(Download.id))
         .select_from(Download.__table__.join(Build).join(Version))
@@ -577,7 +585,8 @@ class Package(db.Model):
         .where(
             db.and_(
                 Version.package_id == id,
-                Download.date >= func.datetime(text("CURRENT_TIMESTAMP"), text("'-90 days'"))
+                Download.date
+                >= func.datetime(text("CURRENT_TIMESTAMP"), text("'-90 days'")),
             )
         )
         .correlate_except(Download)

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -332,9 +332,9 @@ class Build(db.Model):
     firmware_max_id = db.Column(db.Integer, db.ForeignKey("firmware.id"))
     publisher_user_id = db.Column(db.Integer, db.ForeignKey("user.id"))
     checksum = db.Column(db.Unicode(32))
-    extract_size = db.Column(db.Integer)
     path = db.Column(db.Unicode(2048))
     md5 = db.Column(db.Unicode(32))
+    size = db.Column(db.Integer)
     insert_date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
     active = db.Column(db.Boolean(), default=False, nullable=False)
 

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -6,7 +6,7 @@ import shutil
 
 from flask import current_app
 from flask_security import RoleMixin, SQLAlchemyUserDatastore, UserMixin
-from sqlalchemy import event, func, text
+from sqlalchemy import event, text
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Session
@@ -30,6 +30,7 @@ package_user_maintainer = db.Table(
 
 class _days_ago(FunctionElement):
     """Dialect-aware SQL expression for a timestamp N days in the past."""
+
     inherit_cache = True
 
     def __init__(self, days):

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -7,9 +7,11 @@ import shutil
 from flask import current_app
 from flask_security import RoleMixin, SQLAlchemyUserDatastore, UserMixin
 from sqlalchemy import event, func, text
+from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.collections import attribute_mapped_collection
+from sqlalchemy.sql.expression import FunctionElement
 
 from .ext import db
 
@@ -24,6 +26,30 @@ package_user_maintainer = db.Table(
     db.Column("package_id", db.Integer(), db.ForeignKey("package.id")),
     db.Column("user_id", db.Integer(), db.ForeignKey("user.id")),
 )
+
+
+class _days_ago(FunctionElement):
+    """Dialect-aware SQL expression for a timestamp N days in the past."""
+    inherit_cache = True
+
+    def __init__(self, days):
+        self.days = days
+        super().__init__()
+
+
+@compiles(_days_ago, "sqlite")
+def _compile_days_ago_sqlite(element, compiler, **kw):
+    return f"datetime(CURRENT_TIMESTAMP, '-{element.days} days')"
+
+
+@compiles(_days_ago, "postgresql")
+def _compile_days_ago_postgresql(element, compiler, **kw):
+    return f"NOW() - INTERVAL '{element.days} days'"
+
+
+@compiles(_days_ago)
+def _compile_days_ago_default(element, compiler, **kw):
+    return f"datetime(CURRENT_TIMESTAMP, '-{element.days} days')"
 
 
 class User(db.Model, UserMixin):
@@ -585,8 +611,7 @@ class Package(db.Model):
         .where(
             db.and_(
                 Version.package_id == id,
-                Download.date
-                >= func.datetime(text("CURRENT_TIMESTAMP"), text("'-90 days'")),
+                Download.date >= _days_ago(90),
             )
         )
         .correlate_except(Download)

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -6,7 +6,7 @@ import shutil
 
 from flask import current_app
 from flask_security import RoleMixin, SQLAlchemyUserDatastore, UserMixin
-from sqlalchemy import event, text
+from sqlalchemy import event, func
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Session
@@ -327,9 +327,7 @@ class Download(db.Model):
     firmware_build = db.Column(db.Integer, nullable=False)
     ip_address = db.Column(db.Unicode(46), nullable=False)
     user_agent = db.Column(db.Unicode(255))
-    date = db.Column(
-        db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False
-    )
+    date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
 
     # Relationships
     build = db.relationship("Build", back_populates="downloads")
@@ -364,9 +362,7 @@ class Build(db.Model):
     path = db.Column(db.Unicode(2048))
     md5 = db.Column(db.Unicode(32))
     size = db.Column(db.Integer)
-    insert_date = db.Column(
-        db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False
-    )
+    insert_date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
     active = db.Column(db.Boolean(), default=False, nullable=False)
 
     # Relationships
@@ -496,9 +492,7 @@ class Version(db.Model):
     upgrade_wizard = db.Column(db.Boolean)
     startable = db.Column(db.Boolean)
     license = db.Column(db.UnicodeText)
-    insert_date = db.Column(
-        db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False
-    )
+    insert_date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
 
     # Relationships
     package = db.relationship("Package", back_populates="versions", lazy=False)
@@ -596,9 +590,7 @@ class Package(db.Model):
         db.Integer, db.ForeignKey("user.id", ondelete="SET NULL")
     )
     name = db.Column(db.Unicode(50), nullable=False)
-    insert_date = db.Column(
-        db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False
-    )
+    insert_date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
     download_count = db.column_property(
         db.select(db.func.count(Download.id))
         .select_from(Download.__table__.join(Build).join(Version))

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -6,7 +6,7 @@ import shutil
 
 from flask import current_app
 from flask_security import RoleMixin, SQLAlchemyUserDatastore, UserMixin
-from sqlalchemy import event, func
+from sqlalchemy import event
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Session

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -519,7 +519,7 @@ class Version(db.Model):
     @all_builds_active.expression
     def all_builds_active(cls):
         return ~db.exists().where(
-            db.and_(Build.version_id == cls.id, Build.active == False)
+            db.and_(Build.version_id == cls.id, Build.active.is_(False))
         )
 
     @property

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -393,14 +393,22 @@ class Build(db.Model):
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found at path: {file_path}")
 
-        if self.md5 is None:
-            with io.open(file_path, "rb") as f:
-                md5_hash = hashlib.md5()
-                for chunk in iter(lambda: f.read(4096), b""):
-                    md5_hash.update(chunk)
-                return md5_hash.hexdigest()
+        with io.open(file_path, "rb") as f:
+            md5_hash = hashlib.md5()
+            for chunk in iter(lambda: f.read(4096), b""):
+                md5_hash.update(chunk)
+            return md5_hash.hexdigest()
 
-        return self.md5
+    def calculate_size(self):
+        if not self.path:
+            raise ValueError("Path cannot be empty.")
+
+        file_path = os.path.join(current_app.config["DATA_PATH"], self.path)
+
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File not found at path: {file_path}")
+
+        return os.path.getsize(file_path)
 
     def _after_insert(self):
         assert os.path.exists(os.path.join(current_app.config["DATA_PATH"], self.path))

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -510,7 +510,7 @@ class Version(db.Model):
     def all_builds_active(self):
         return all(b.active for b in self.builds)
 
-    @hybrid_property
+    @property
     def any_builds_active(self):
         return any(b.active for b in self.builds)
 
@@ -548,7 +548,7 @@ class Version(db.Model):
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.version_string}>"
 
-    @hybrid_property
+    @property
     def builds_per_dsm(self):
         result = {}
         for build in self.builds:
@@ -612,7 +612,7 @@ class Package(db.Model):
     # Constraints
     __table_args__ = (db.UniqueConstraint(name),)
 
-    @hybrid_property
+    @property
     def any_builds_active(self):
         return any(v.any_builds_active for v in self.versions)
 

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -3,11 +3,11 @@ import hashlib
 import io
 import os
 import shutil
-from datetime import datetime, timedelta
 
 from flask import current_app
 from flask_security import RoleMixin, SQLAlchemyUserDatastore, UserMixin
-from flask_sqlalchemy import track_modifications
+from sqlalchemy import event, func, text
+from sqlalchemy.orm import Session
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm.collections import attribute_mapped_collection
 
@@ -300,7 +300,7 @@ class Download(db.Model):
     firmware_build = db.Column(db.Integer, nullable=False)
     ip_address = db.Column(db.Unicode(46), nullable=False)
     user_agent = db.Column(db.Unicode(255))
-    date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
+    date = db.Column(db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
 
     # Relationships
     build = db.relationship("Build", back_populates="downloads")
@@ -335,7 +335,7 @@ class Build(db.Model):
     path = db.Column(db.Unicode(2048))
     md5 = db.Column(db.Unicode(32))
     size = db.Column(db.Integer)
-    insert_date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
+    insert_date = db.Column(db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
     active = db.Column(db.Boolean(), default=False, nullable=False)
 
     # Relationships
@@ -465,7 +465,7 @@ class Version(db.Model):
     upgrade_wizard = db.Column(db.Boolean)
     startable = db.Column(db.Boolean)
     license = db.Column(db.UnicodeText)
-    insert_date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
+    insert_date = db.Column(db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
 
     # Relationships
     package = db.relationship("Package", back_populates="versions", lazy=False)
@@ -499,40 +499,34 @@ class Version(db.Model):
     __table_args__ = (db.UniqueConstraint(package_id, version),)
 
     @hybrid_property
-    def version_string(self):
-        return self.upstream_version + "-" + str(self.version)
-
-    @hybrid_property
     def beta(self):
         return bool(self.report_url)  # Treats None and "" as False
-
-    @hybrid_property
-    def all_builds_active(self):
-        return all(b.active for b in self.builds)
-
-    @property
-    def any_builds_active(self):
-        return any(b.active for b in self.builds)
-
-    @all_builds_active.expression
-    def all_builds_active(cls):
-        return (
-            db.select(db.func.count())
-            .where(db.and_(Build.version_id == cls.id, Build.active))
-            .label("active_builds")
-        ) == (
-            db.select(db.func.count())
-            .where(Build.version_id == cls.id)
-            .label("total_builds")
-        )
 
     @beta.expression
     def beta(cls):
         return db.and_(cls.report_url.isnot(None), cls.report_url != "")
 
+    @hybrid_property
+    def all_builds_active(self):
+        return all(b.active for b in self.builds)
+
+    @all_builds_active.expression
+    def all_builds_active(cls):
+        return ~db.exists().where(
+            db.and_(Build.version_id == cls.id, Build.active == False)
+        )
+
+    @property
+    def any_builds_active(self):
+        return any(b.active for b in self.builds)
+
     @property
     def path(self):
         return os.path.join(self.package.name, str(self.version))
+
+    @property
+    def version_string(self):
+        return self.upstream_version + "-" + str(self.version)
 
     def _after_insert(self):
         assert os.path.exists(os.path.join(current_app.config["DATA_PATH"], self.path))
@@ -569,7 +563,7 @@ class Package(db.Model):
         db.Integer, db.ForeignKey("user.id", ondelete="SET NULL")
     )
     name = db.Column(db.Unicode(50), nullable=False)
-    insert_date = db.Column(db.DateTime, default=db.func.now(), nullable=False)
+    insert_date = db.Column(db.DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
     download_count = db.column_property(
         db.select(db.func.count(Download.id))
         .select_from(Download.__table__.join(Build).join(Version))
@@ -583,7 +577,7 @@ class Package(db.Model):
         .where(
             db.and_(
                 Version.package_id == id,
-                Download.date >= datetime.now() - timedelta(days=90),
+                Download.date >= func.datetime(text("CURRENT_TIMESTAMP"), text("'-90 days'"))
             )
         )
         .correlate_except(Download)
@@ -627,19 +621,42 @@ class Package(db.Model):
         return f"<{self.__class__.__name__} {self.name}>"
 
 
-@track_modifications.models_committed.connect
-def on_models_committed(sender, changes):
-    for obj, change in changes:
-        if change == "insert" and hasattr(obj, "_after_insert"):
-            obj._after_insert()
-        elif change == "delete" and hasattr(obj, "_after_delete"):
-            obj._after_delete()
+def _before_insert_handler(mapper, connection, target):
+    if hasattr(target, "_before_insert"):
+        target._before_insert()
 
 
-@track_modifications.before_models_committed.connect
-def on_before_models_committed(sender, changes):
-    for obj, change in changes:
-        if change == "insert" and hasattr(obj, "_before_insert"):
-            obj._before_insert()
-        elif change == "delete" and hasattr(obj, "_before_delete"):
-            obj._before_delete()
+def _after_insert_handler(mapper, connection, target):
+    if not hasattr(target, "_after_insert"):
+        return
+    session = Session.object_session(target)
+    if session is None:
+        return
+
+    @event.listens_for(session, "after_commit", once=True)
+    def on_commit(session):
+        target._after_insert()
+
+
+def _before_delete_handler(mapper, connection, target):
+    if hasattr(target, "_before_delete"):
+        target._before_delete()
+
+
+def _after_delete_handler(mapper, connection, target):
+    if not hasattr(target, "_after_delete"):
+        return
+    session = Session.object_session(target)
+    if session is None:
+        return
+
+    @event.listens_for(session, "after_commit", once=True)
+    def on_commit(session):
+        target._after_delete()
+
+
+for _model in [Screenshot, Icon, Build, Version]:
+    event.listen(_model, "before_insert", _before_insert_handler)
+    event.listen(_model, "after_insert", _after_insert_handler)
+    event.listen(_model, "before_delete", _before_delete_handler)
+    event.listen(_model, "after_delete", _after_delete_handler)

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -544,10 +544,6 @@ class Version(db.Model):
         )
 
     @property
-    def any_builds_active(self):
-        return any(b.active for b in self.builds)
-
-    @property
     def path(self):
         return os.path.join(self.package.name, str(self.version))
 
@@ -632,10 +628,6 @@ class Package(db.Model):
 
     # Constraints
     __table_args__ = (db.UniqueConstraint(name),)
-
-    @property
-    def any_builds_active(self):
-        return any(v.any_builds_active for v in self.versions)
 
     @classmethod
     def find(cls, name):

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -547,6 +547,10 @@ class Version(db.Model):
             result.setdefault(build.firmware_min.version[0:1], []).append(build)
         return result
 
+    @property
+    def total_size(self):
+        return sum(b.size for b in self.builds if b.size is not None) or None
+
 
 class Package(db.Model):
     __tablename__ = "package"

--- a/spkrepo/templates/admin/index.html
+++ b/spkrepo/templates/admin/index.html
@@ -4,12 +4,12 @@
 <div class="container-fluid" style="margin-top: 20px;">
 
   {# Back to site + logged in user #}
-  <div class="row" style="margin-bottom: 15px;">
-    <div class="col-md-12">
-      <a href="{{ url_for('frontend.index') }}" class="btn btn-default btn-sm">
+  <div class="row mb-4">
+    <div class="col">
+      <a href="{{ url_for('frontend.index') }}" class="btn btn-secondary btn-sm">
         &larr; Back to Spkrepo
       </a>
-      <span class="text-muted" style="margin-left: 10px; font-size: 0.9em;">
+      <span class="text-muted ml-2" style="font-size: 0.9em;">
         Logged in as <strong>{{ current_user.email }}</strong>
       </span>
     </div>
@@ -17,41 +17,41 @@
 
   {# Stat tiles #}
   {% set col_width = 'col-md-3 col-sm-6' if unconfirmed_user_count is not none else 'col-md-4 col-sm-6' %}
-  <div class="row" style="margin-top: 25px; margin-bottom: 25px;">
+  <div class="row mb-2">
 
-    <div class="{{ col_width }}">
-      <div class="panel panel-info">
-        <div class="panel-heading" style="font-size: 0.85em;">Packages</div>
-        <div class="panel-body" style="font-size: 2em; text-align: center; background-color: #f5f5f5;">
-          {{ package_count }}
+    <div class="{{ col_width }} mb-3">
+      <div class="card border-info h-100">
+        <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Packages</div>
+        <div class="card-body bg-light d-flex align-items-center justify-content-center">
+          <span style="font-size: 2em;">{{ package_count }}</span>
         </div>
       </div>
     </div>
 
-    <div class="{{ col_width }}">
-      <div class="panel panel-info">
-        <div class="panel-heading" style="font-size: 0.85em;">Builds</div>
-        <div class="panel-body" style="font-size: 2em; text-align: center; background-color: #f5f5f5;">
-          {{ build_count }}
+    <div class="{{ col_width }} mb-3">
+      <div class="card border-info h-100">
+        <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Builds</div>
+        <div class="card-body bg-light d-flex align-items-center justify-content-center">
+          <span style="font-size: 2em;">{{ build_count }}</span>
         </div>
       </div>
     </div>
 
-    <div class="{{ col_width }}">
-      <div class="panel {% if inactive_build_count > 0 %}panel-warning{% else %}panel-info{% endif %}">
-        <div class="panel-heading" style="font-size: 0.85em;">Inactive Builds</div>
-        <div class="panel-body" style="font-size: 2em; text-align: center; background-color: #f5f5f5;">
-          {{ inactive_build_count }}
+    <div class="{{ col_width }} mb-3">
+      <div class="card {% if inactive_build_count > 0 %}border-warning{% else %}border-info{% endif %} h-100">
+        <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Inactive Builds</div>
+        <div class="card-body bg-light d-flex align-items-center justify-content-center">
+          <span style="font-size: 2em;">{{ inactive_build_count }}</span>
         </div>
       </div>
     </div>
 
     {% if unconfirmed_user_count is not none %}
-    <div class="{{ col_width }}">
-      <div class="panel {% if unconfirmed_user_count > 0 %}panel-warning{% else %}panel-info{% endif %}">
-        <div class="panel-heading" style="font-size: 0.85em;">Unconfirmed Users</div>
-        <div class="panel-body" style="font-size: 2em; text-align: center; background-color: #f5f5f5;">
-          {{ unconfirmed_user_count }}
+    <div class="{{ col_width }} mb-3">
+      <div class="card {% if unconfirmed_user_count > 0 %}border-warning{% else %}border-info{% endif %} h-100">
+        <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Unconfirmed Users</div>
+        <div class="card-body bg-light d-flex align-items-center justify-content-center">
+          <span style="font-size: 2em;">{{ unconfirmed_user_count }}</span>
         </div>
       </div>
     </div>
@@ -61,10 +61,10 @@
 
   {# Last 5 versions uploaded #}
   <div class="row">
-    <div class="col-md-12">
-      <div class="panel panel-info">
-        <div class="panel-heading" style="font-size: 0.85em;">Last 5 Versions Uploaded</div>
-        <table class="table table-striped table-hover" style="margin-bottom: 0;">
+    <div class="col">
+      <div class="card border-info">
+        <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Last 5 Versions Uploaded</div>
+        <table class="table table-striped table-hover mb-0">
           <thead>
             <tr>
               <th>Package</th>

--- a/spkrepo/templates/admin/index.html
+++ b/spkrepo/templates/admin/index.html
@@ -1,0 +1,104 @@
+{% extends 'admin/master.html' %}
+
+{% block body %}
+<div class="container-fluid" style="margin-top: 20px;">
+
+  {# Back to site + logged in user #}
+  <div class="row" style="margin-bottom: 15px;">
+    <div class="col-md-12">
+      <a href="{{ url_for('frontend.index') }}" class="btn btn-default btn-sm">
+        &larr; Back to Spkrepo
+      </a>
+      <span class="text-muted" style="margin-left: 10px; font-size: 0.9em;">
+        Logged in as <strong>{{ current_user.email }}</strong>
+      </span>
+    </div>
+  </div>
+
+  {# Stat tiles #}
+  {% set col_width = 'col-md-3 col-sm-6' if unconfirmed_user_count is not none else 'col-md-4 col-sm-6' %}
+  <div class="row" style="margin-top: 25px; margin-bottom: 25px;">
+
+    <div class="{{ col_width }}">
+      <div class="panel panel-info">
+        <div class="panel-heading" style="font-size: 0.85em;">Packages</div>
+        <div class="panel-body" style="font-size: 2em; text-align: center; background-color: #f5f5f5;">
+          {{ package_count }}
+        </div>
+      </div>
+    </div>
+
+    <div class="{{ col_width }}">
+      <div class="panel panel-info">
+        <div class="panel-heading" style="font-size: 0.85em;">Builds</div>
+        <div class="panel-body" style="font-size: 2em; text-align: center; background-color: #f5f5f5;">
+          {{ build_count }}
+        </div>
+      </div>
+    </div>
+
+    <div class="{{ col_width }}">
+      <div class="panel {% if inactive_build_count > 0 %}panel-warning{% else %}panel-info{% endif %}">
+        <div class="panel-heading" style="font-size: 0.85em;">Inactive Builds</div>
+        <div class="panel-body" style="font-size: 2em; text-align: center; background-color: #f5f5f5;">
+          {{ inactive_build_count }}
+        </div>
+      </div>
+    </div>
+
+    {% if unconfirmed_user_count is not none %}
+    <div class="{{ col_width }}">
+      <div class="panel {% if unconfirmed_user_count > 0 %}panel-warning{% else %}panel-info{% endif %}">
+        <div class="panel-heading" style="font-size: 0.85em;">Unconfirmed Users</div>
+        <div class="panel-body" style="font-size: 2em; text-align: center; background-color: #f5f5f5;">
+          {{ unconfirmed_user_count }}
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
+  </div>
+
+  {# Last 5 versions uploaded #}
+  <div class="row">
+    <div class="col-md-12">
+      <div class="panel panel-info">
+        <div class="panel-heading" style="font-size: 0.85em;">Last 5 Versions Uploaded</div>
+        <table class="table table-striped table-hover" style="margin-bottom: 0;">
+          <thead>
+            <tr>
+              <th>Package</th>
+              <th>Version</th>
+              <th>Total Size</th>
+              <th>All Active</th>
+              <th>Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for version in recent_versions %}
+            <tr>
+              <td>{{ version.package.name }}</td>
+              <td>{{ version.upstream_version }}-{{ version.version }}</td>
+              <td>{{ '%.1f MB' % (version.total_size / 1024 / 1024) if version.total_size else '—' }}</td>
+              <td>
+                {% if version.all_builds_active %}
+                  <i class="fa fa-check-circle" style="color: #27ae60;"></i>
+                {% else %}
+                  <i class="fa fa-times-circle" style="color: #e74c3c;"></i>
+                {% endif %}
+              </td>
+              <td>{{ version.insert_date.strftime('%Y-%m-%d %H:%M') }}</td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="5" class="text-center text-muted">No versions uploaded yet.</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+</div>
+{% endblock %}

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -98,7 +98,7 @@ class UserTestCase(BaseTestCase):
             self.assertTrue(user1.active)
             self.assertTrue(user2.active)
 
-    def test_action_deactivate(self):
+    def test_action_deactivate_one(self):
         with self.logged_user("admin"):
             user = self.create_user()
             user.active = True
@@ -267,7 +267,12 @@ class VersionTestCase(BaseTestCase):
         self.assertTrue({"72", "256"}.intersection(refreshed_version.icons.keys()))
 
     def test_action_resync_info_refreshes_build_metadata(self):
-        build = BuildFactory()
+        # Pin firmware_min to the lowest seeded firmware so we can always find
+        # a different one to corrupt the build with, making the restore assertion meaningful.
+        build = BuildFactory(
+            firmware_min=Firmware.query.order_by(Firmware.build.asc()).first(),
+            firmware_max=Firmware.query.order_by(Firmware.build.desc()).first(),
+        )
         db.session.commit()
 
         version = build.version
@@ -277,11 +282,12 @@ class VersionTestCase(BaseTestCase):
         original_dependencies = build.buildmanifest.dependencies
         original_conf_privilege = build.buildmanifest.conf_privilege
 
-        alternative_firmware = Firmware.query.filter(
+        # Corrupt the build — use a firmware that is guaranteed to differ
+        corrupting_firmware = Firmware.query.filter(
             Firmware.id != original_firmware_min.id
         ).first()
-        if alternative_firmware is not None:
-            build.firmware_min = alternative_firmware
+        self.assertIsNotNone(corrupting_firmware, "Need at least 2 firmware entries")
+        build.firmware_min = corrupting_firmware
         build.firmware_max = None
         build.architectures = []
         build.buildmanifest.dependencies = None
@@ -290,6 +296,10 @@ class VersionTestCase(BaseTestCase):
         build.md5 = None
 
         db.session.commit()
+
+        # Verify the corruption took effect so we know the resync is actually doing work
+        self.assertNotEqual(build.firmware_min.id, original_firmware_min.id)
+        self.assertIsNone(build.firmware_max)
 
         with self.logged_user("package_admin", "admin"):
             response = self.client.post(
@@ -308,13 +318,9 @@ class VersionTestCase(BaseTestCase):
             original_architectures,
         )
         self.assertEqual(refreshed_build.firmware_min.id, original_firmware_min.id)
-        if original_firmware_max is None:
-            self.assertIsNone(refreshed_build.firmware_max)
-        else:
-            self.assertEqual(
-                refreshed_build.firmware_max.id,
-                original_firmware_max.id,
-            )
+        # firmware_max was set to a known value and should be restored
+        self.assertIsNotNone(refreshed_build.firmware_max)
+        self.assertEqual(refreshed_build.firmware_max.id, original_firmware_max.id)
         self.assertEqual(
             refreshed_build.buildmanifest.dependencies,
             original_dependencies,
@@ -354,6 +360,104 @@ class VersionTestCase(BaseTestCase):
         self.assertEqual(refreshed_build.md5, refreshed_build.calculate_md5())
         self.assertIsNotNone(refreshed_build.size)
         self.assertGreater(refreshed_build.size, 0)
+
+    def test_action_activate_one(self):
+        build = BuildFactory(active=False)
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="activate", rowid=[build.version.id]),
+            )
+            self.assert200(response)
+            self.assertIn(
+                "Builds on version were successfully activated.",
+                response.data.decode(),
+            )
+        db.session.expire_all()
+        self.assertTrue(db.session.get(Build, build.id).active)
+
+    def test_action_activate_multi(self):
+        build1 = BuildFactory(active=False)
+        build2 = BuildFactory(active=False)
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(
+                    action="activate",
+                    rowid=[build1.version.id, build2.version.id],
+                ),
+            )
+            self.assert200(response)
+            self.assertIn(
+                "Builds have been successfully activated for 2 versions.",
+                response.data.decode(),
+            )
+        db.session.expire_all()
+        self.assertTrue(db.session.get(Build, build1.id).active)
+        self.assertTrue(db.session.get(Build, build2.id).active)
+
+    def test_action_deactivate_one(self):
+        build = BuildFactory(active=True)
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="deactivate", rowid=[build.version.id]),
+            )
+            self.assert200(response)
+            self.assertIn(
+                "Builds on version were successfully deactivated.",
+                response.data.decode(),
+            )
+        db.session.expire_all()
+        self.assertFalse(db.session.get(Build, build.id).active)
+
+    def test_action_deactivate_multi(self):
+        build1 = BuildFactory(active=True)
+        build2 = BuildFactory(active=True)
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(
+                    action="deactivate",
+                    rowid=[build1.version.id, build2.version.id],
+                ),
+            )
+            self.assert200(response)
+            self.assertIn(
+                "Builds have been successfully deactivated for 2 versions.",
+                response.data.decode(),
+            )
+        db.session.expire_all()
+        self.assertFalse(db.session.get(Build, build1.id).active)
+        self.assertFalse(db.session.get(Build, build2.id).active)
+
+    def test_action_resync_info_blocked_for_non_admin(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                data=dict(action="resync_info", rowid=[build.version.id]),
+            )
+        self.assert403(response)
+
+    def test_action_resync_file_blocked_for_non_admin(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                data=dict(action="resync_file", rowid=[build.version.id]),
+            )
+        self.assert403(response)
 
 
 class BuildTestCase(BaseTestCase):
@@ -410,7 +514,7 @@ class BuildTestCase(BaseTestCase):
             self.assertTrue(build1.active)
             self.assertTrue(build2.active)
 
-    def test_action_deactivate(self):
+    def test_action_deactivate_one(self):
         with self.logged_user("package_admin"):
             build = BuildFactory(active=True)
             db.session.commit()
@@ -527,6 +631,39 @@ class BuildTestCase(BaseTestCase):
         self.assertIsNotNone(refreshed_build.size)
         self.assertGreater(refreshed_build.size, 0)
 
+    def test_action_resync_info_blocked_for_non_admin(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                data=dict(action="resync_info", rowid=[build.id]),
+            )
+        self.assert403(response)
+
+    def test_action_resync_file_blocked_for_non_admin(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                data=dict(action="resync_file", rowid=[build.id]),
+            )
+        self.assert403(response)
+
+    def test_developer_sees_only_maintainer_builds(self):
+        # A developer who is a maintainer on a package sees only that package's builds.
+        with self.logged_user("developer") as user:
+            own_package = PackageFactory(maintainers=[user])
+            BuildFactory(version__package=own_package)  # creates the build on disk
+            other_build = BuildFactory()
+            db.session.commit()
+            response = self.client.get(url_for("build.index_view"))
+            self.assert200(response)
+            response_data = response.data.decode()
+            self.assertIn(own_package.name, response_data)
+            self.assertNotIn(other_build.version.package.name, response_data)
+
 
 class ScreenshotTestCase(BaseTestCase):
     def test_anonymous(self):
@@ -562,3 +699,31 @@ class ScreenshotTestCase(BaseTestCase):
             )
         self.assertEqual(len(package.screenshots), 1)
         self.assertTrue(package.screenshots[0].path.endswith("screenshot_1.png"))
+
+
+class ScreenshotDeleteTestCase(BaseTestCase):
+    def test_delete_removes_file(self):
+        package = PackageFactory(add_screenshot=False)
+        db.session.commit()
+        # Use a single logged_user context so create and delete are performed
+        # by the same user, matching the normal admin workflow.
+        with self.logged_user("package_admin"):
+            self.client.post(
+                url_for("screenshot.create_view"),
+                data=dict(
+                    package=str(package.id),
+                    path=(create_image("Delete Test", 1280, 1024), "test.png"),
+                ),
+            )
+            db.session.expire_all()
+            self.assertEqual(len(package.screenshots), 1)
+            screenshot = package.screenshots[0]
+            screenshot_path = os.path.join(
+                current_app.config["DATA_PATH"], screenshot.path
+            )
+            self.assertTrue(os.path.exists(screenshot_path))
+
+            self.client.post(url_for("screenshot.delete_view", id=str(screenshot.id)))
+        db.session.expire_all()
+        self.assertEqual(len(package.screenshots), 0)
+        self.assertFalse(os.path.exists(screenshot_path))

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -210,14 +210,13 @@ class VersionTestCase(BaseTestCase):
         self.assertEqual(len(Version.query.all()), 0)
         self.assertTrue(not os.path.exists(version_path))
 
-    def test_action_resync_requires_admin(self):
+    def test_action_resync_info_requires_admin(self):
         with self.logged_user("package_admin"):
             response = self.client.get(url_for("version.index_view"))
             self.assert200(response)
             self.assertNotIn("Resync Info", response.data.decode())
-            self.assertNotIn("Resync File", response.data.decode())
 
-    def test_action_resync_refreshes_metadata(self):
+    def test_action_resync_info_refreshes_version_metadata(self):
         build = BuildFactory()
         db.session.commit()
 
@@ -229,11 +228,6 @@ class VersionTestCase(BaseTestCase):
         )
         original_upstream = version.upstream_version
         original_license = version.license
-        original_architectures = sorted(arch.code for arch in build.architectures)
-        original_firmware_min = build.firmware_min
-        original_firmware_max = build.firmware_max
-        original_dependencies = build.buildmanifest.dependencies
-        original_conf_privilege = build.buildmanifest.conf_privilege
 
         version.displaynames["enu"].displayname = "Changed"
         version.descriptions["enu"].description = "Changed"
@@ -243,6 +237,45 @@ class VersionTestCase(BaseTestCase):
 
         for key in list(version.icons.keys()):
             del version.icons[key]
+
+        db.session.commit()
+
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[version.id]),
+            )
+            self.assert200(response)
+            self.assertIn("refreshed", response.data.decode())
+
+        db.session.expire_all()
+        refreshed_version = db.session.get(Build, build.id).version
+
+        self.assertEqual(
+            refreshed_version.displaynames["enu"].displayname, original_display
+        )
+        self.assertEqual(
+            refreshed_version.descriptions["enu"].description, original_description
+        )
+        self.assertEqual(
+            sorted(service.code for service in refreshed_version.service_dependencies),
+            original_services,
+        )
+        self.assertEqual(refreshed_version.upstream_version, original_upstream)
+        self.assertEqual(refreshed_version.license, original_license)
+        self.assertTrue({"72", "256"}.intersection(refreshed_version.icons.keys()))
+
+    def test_action_resync_info_refreshes_build_metadata(self):
+        build = BuildFactory()
+        db.session.commit()
+
+        version = build.version
+        original_architectures = sorted(arch.code for arch in build.architectures)
+        original_firmware_min = build.firmware_min
+        original_firmware_max = build.firmware_max
+        original_dependencies = build.buildmanifest.dependencies
+        original_conf_privilege = build.buildmanifest.conf_privilege
 
         alternative_firmware = Firmware.query.filter(
             Firmware.id != original_firmware_min.id
@@ -269,21 +302,7 @@ class VersionTestCase(BaseTestCase):
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
-        refreshed_version = refreshed_build.version
 
-        self.assertEqual(
-            refreshed_version.displaynames["enu"].displayname, original_display
-        )
-        self.assertEqual(
-            refreshed_version.descriptions["enu"].description, original_description
-        )
-        self.assertEqual(
-            sorted(service.code for service in refreshed_version.service_dependencies),
-            original_services,
-        )
-        self.assertEqual(refreshed_version.upstream_version, original_upstream)
-        self.assertEqual(refreshed_version.license, original_license)
-        self.assertTrue({"72", "256"}.intersection(refreshed_version.icons.keys()))
         self.assertEqual(
             sorted(arch.code for arch in refreshed_build.architectures),
             original_architectures,
@@ -425,21 +444,41 @@ class BuildTestCase(BaseTestCase):
             self.assertFalse(build1.active)
             self.assertFalse(build2.active)
 
-    def test_action_resync_requires_admin(self):
+    def test_action_resync_info_requires_admin(self):
         with self.logged_user("package_admin"):
             response = self.client.get(url_for("build.index_view"))
             self.assert200(response)
             self.assertNotIn("Resync Info", response.data.decode())
-            self.assertNotIn("Resync File", response.data.decode())
 
-    def test_action_resync_refreshes_single_build(self):
+    def test_action_resync_info_refreshes_version_metadata(self):
         build = BuildFactory()
         db.session.commit()
 
         original_display = build.version.displaynames["enu"].displayname
-        original_architectures = sorted(arch.code for arch in build.architectures)
-
         build.version.displaynames["enu"].displayname = "Altered"
+        db.session.commit()
+
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build.id]),
+            )
+            self.assert200(response)
+            self.assertIn("refreshed", response.data.decode())
+
+        db.session.expire_all()
+        refreshed_build = db.session.get(Build, build.id)
+        self.assertEqual(
+            refreshed_build.version.displaynames["enu"].displayname,
+            original_display,
+        )
+
+    def test_action_resync_info_refreshes_build_metadata(self):
+        build = BuildFactory()
+        db.session.commit()
+
+        original_architectures = sorted(arch.code for arch in build.architectures)
         build.architectures = []
         db.session.commit()
 
@@ -454,11 +493,6 @@ class BuildTestCase(BaseTestCase):
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
-
-        self.assertEqual(
-            refreshed_build.version.displaynames["enu"].displayname,
-            original_display,
-        )
         self.assertEqual(
             sorted(arch.code for arch in refreshed_build.architectures),
             original_architectures,

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -268,7 +268,8 @@ class VersionTestCase(BaseTestCase):
 
     def test_action_resync_info_refreshes_build_metadata(self):
         # Pin firmware_min to the lowest seeded firmware so we can always find
-        # a different one to corrupt the build with, making the restore assertion meaningful.
+        # a different one to corrupt the build with, making the
+        # restore assertion meaningful.
         build = BuildFactory(
             firmware_min=Firmware.query.order_by(Firmware.build.asc()).first(),
             firmware_max=Firmware.query.order_by(Firmware.build.desc()).first(),

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -214,7 +214,8 @@ class VersionTestCase(BaseTestCase):
         with self.logged_user("package_admin"):
             response = self.client.get(url_for("version.index_view"))
             self.assert200(response)
-            self.assertNotIn("Resync INFO", response.data.decode())
+            self.assertNotIn("Resync Info", response.data.decode())
+            self.assertNotIn("Resync File", response.data.decode())
 
     def test_action_resync_refreshes_metadata(self):
         build = BuildFactory()
@@ -264,7 +265,7 @@ class VersionTestCase(BaseTestCase):
                 data=dict(action="resync_info", rowid=[version.id]),
             )
             self.assert200(response)
-            self.assertIn("metadata refreshed from INFO", response.data.decode())
+            self.assertIn("refreshed", response.data.decode())
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
@@ -304,6 +305,36 @@ class VersionTestCase(BaseTestCase):
             original_conf_privilege,
         )
         self.assertEqual(refreshed_build.md5, refreshed_build.calculate_md5())
+
+    def test_action_resync_file_requires_admin(self):
+        with self.logged_user("package_admin"):
+            response = self.client.get(url_for("version.index_view"))
+            self.assert200(response)
+            self.assertNotIn("Resync File", response.data.decode())
+
+    def test_action_resync_file_refreshes_builds(self):
+        build = BuildFactory()
+        db.session.commit()
+
+        version = build.version
+        build.md5 = None
+        build.size = None
+        db.session.commit()
+
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_file", rowid=[version.id]),
+            )
+            self.assert200(response)
+            self.assertIn("refreshed", response.data.decode())
+
+        db.session.expire_all()
+        refreshed_build = db.session.get(Build, build.id)
+        self.assertEqual(refreshed_build.md5, refreshed_build.calculate_md5())
+        self.assertIsNotNone(refreshed_build.size)
+        self.assertGreater(refreshed_build.size, 0)
 
 
 class BuildTestCase(BaseTestCase):
@@ -398,7 +429,8 @@ class BuildTestCase(BaseTestCase):
         with self.logged_user("package_admin"):
             response = self.client.get(url_for("build.index_view"))
             self.assert200(response)
-            self.assertNotIn("Resync INFO", response.data.decode())
+            self.assertNotIn("Resync Info", response.data.decode())
+            self.assertNotIn("Resync File", response.data.decode())
 
     def test_action_resync_refreshes_single_build(self):
         build = BuildFactory()
@@ -418,7 +450,7 @@ class BuildTestCase(BaseTestCase):
                 data=dict(action="resync_info", rowid=[build.id]),
             )
             self.assert200(response)
-            self.assertIn("metadata refreshed from INFO", response.data.decode())
+            self.assertIn("refreshed", response.data.decode())
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
@@ -431,6 +463,35 @@ class BuildTestCase(BaseTestCase):
             sorted(arch.code for arch in refreshed_build.architectures),
             original_architectures,
         )
+
+    def test_action_resync_file_requires_admin(self):
+        with self.logged_user("package_admin"):
+            response = self.client.get(url_for("build.index_view"))
+            self.assert200(response)
+            self.assertNotIn("Resync File", response.data.decode())
+
+    def test_action_resync_file_refreshes_single_build(self):
+        build = BuildFactory()
+        db.session.commit()
+
+        build.md5 = None
+        build.size = None
+        db.session.commit()
+
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_file", rowid=[build.id]),
+            )
+            self.assert200(response)
+            self.assertIn("refreshed", response.data.decode())
+
+        db.session.expire_all()
+        refreshed_build = db.session.get(Build, build.id)
+        self.assertEqual(refreshed_build.md5, refreshed_build.calculate_md5())
+        self.assertIsNotNone(refreshed_build.size)
+        self.assertGreater(refreshed_build.size, 0)
 
 
 class ScreenshotTestCase(BaseTestCase):

--- a/spkrepo/tests/test_api.py
+++ b/spkrepo/tests/test_api.py
@@ -550,3 +550,65 @@ class PackagesTestCase(BaseTestCase):
             )
         self.assert422(response)
         self.assertIn("Invalid SPK", response.data.decode())
+
+    def test_post_existing_version_matching_upstream(self):
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(
+            version__upstream_version="1.0.0",
+            architectures=[Architecture.find("88f6281", syno=True)],
+        )
+        with create_spk(build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+        new_build = BuildFactory.build(
+            version=build.version,
+            architectures=[Architecture.find("cedarview", syno=True)],
+        )
+        with create_spk(new_build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+    def test_post_existing_version_mismatched_upstream(self):
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(
+            version__upstream_version="1.0.0",
+            architectures=[Architecture.find("88f6281", syno=True)],
+        )
+        with create_spk(build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+        new_build = BuildFactory.build(
+            version__upstream_version="2.0.0",
+            version__version=build.version.version,
+            version__package=build.version.package,
+            architectures=[Architecture.find("cedarview", syno=True)],
+        )
+        with create_spk(new_build) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert422(response)
+        self.assertIn("Upstream version mismatch", response.data.decode())

--- a/spkrepo/tests/test_api.py
+++ b/spkrepo/tests/test_api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+import json
 import os
 import warnings
 from datetime import datetime, timedelta, timezone
@@ -90,10 +91,12 @@ class PackagesTestCase(BaseTestCase):
         self.assertEqual(
             inserted_build.version.upgrade_wizard, build.version.upgrade_wizard
         )
-        self.assertEqual(
-            inserted_build.version.startable,
-            True if build.version.startable is None else build.version.startable,
+        # api.py defaults version_startable=True when INFO omits the startable key,
+        # so a factory build with startable=None should be inserted as startable=True.
+        expected_startable = (
+            True if build.version.startable is None else build.version.startable
         )
+        self.assertEqual(inserted_build.version.startable, expected_startable)
         self.assertEqual(inserted_build.version.license, build.version.license)
 
         # manifest
@@ -143,7 +146,8 @@ class PackagesTestCase(BaseTestCase):
         self.assert401(self.client.post(url_for("api.packages")))
 
     def test_post_simple_user(self):
-        user = UserFactory()
+        # A user with a valid api_key but no developer role must be rejected.
+        user = UserFactory(roles=[])
         db.session.commit()
 
         self.assert401(
@@ -207,7 +211,11 @@ class PackagesTestCase(BaseTestCase):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
         db.session.commit()
 
-        base_build = BuildFactory.build(architectures=[Architecture.find("noarch")])
+        # Pin to the lowest seeded firmware so newer_firmware is always strictly higher.
+        base_build = BuildFactory.build(
+            architectures=[Architecture.find("noarch")],
+            firmware_min=Firmware.query.order_by(Firmware.build.asc()).first(),
+        )
         with (
             create_spk(base_build) as spk,
             warnings.catch_warnings(record=True) as base_warns,
@@ -228,12 +236,15 @@ class PackagesTestCase(BaseTestCase):
             ),
         )
 
-        newer_firmware = (
-            Firmware.query.filter(Firmware.build != base_build.firmware_min.build)
-            .order_by(Firmware.build.desc())
-            .first()
-        )
+        # Always use the highest seeded firmware to guarantee it is genuinely newer
+        # than whatever the factory picked for base_build, avoiding a flaky fixture.
+        newer_firmware = Firmware.query.order_by(Firmware.build.desc()).first()
         self.assertIsNotNone(newer_firmware)
+        self.assertGreater(
+            newer_firmware.build,
+            base_build.firmware_min.build,
+            "Expected newer_firmware to be strictly higher than base firmware",
+        )
 
         followup_build = BuildFactory.build(
             version=base_build.version,
@@ -612,3 +623,209 @@ class PackagesTestCase(BaseTestCase):
             )
         self.assert422(response)
         self.assertIn("Upstream version mismatch", response.data.decode())
+
+    def test_post_201_response_body(self):
+        # The 201 response body must contain package, version, firmware, architectures.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(
+            architectures=[Architecture.find("88f628x")],
+            firmware_min=Firmware.find(1594),
+        )
+        with create_spk(build) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert201(response)
+        body = json.loads(response.data.decode())
+        self.assertEqual(body["package"], build.version.package.name)
+        self.assertEqual(body["version"], build.version.version_string)
+        self.assertEqual(body["firmware"], build.firmware_min.firmware_string)
+        self.assertEqual(body["architectures"], ["88f628x"])
+
+    def test_post_with_firmware_max(self):
+        # A build with firmware_max set should be accepted and stored correctly.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(
+            firmware_min=Firmware.find(1594),
+            firmware_max=Firmware.find(4458),
+        )
+        with create_spk(build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+        self.assertBuildInserted(Build.query.one(), build, user)
+
+    def test_post_invalid_firmware_max(self):
+        # os_max_ver that doesn't match the firmware regex returns 422.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(firmware_min=Firmware.find(1594))
+        info = create_info(build)
+        info["os_max_ver"] = "not-a-firmware"
+        with create_spk(build, info=info) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert422(response)
+        self.assertIn("Invalid maximum firmware", response.data.decode())
+
+    def test_post_unknown_firmware_max(self):
+        # os_max_ver with valid format but unknown build number returns 422.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(firmware_min=Firmware.find(1594))
+        info = create_info(build)
+        info["os_max_ver"] = "5.0-9999"
+        with create_spk(build, info=info) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert422(response)
+        self.assertIn("Unknown maximum firmware", response.data.decode())
+
+    def test_post_firmware_max_less_than_firmware_min(self):
+        # os_max_ver < firmware returns 422.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        # firmware_min=4458, firmware_max=1594 (max < min)
+        build = BuildFactory.build(firmware_min=Firmware.find(4458))
+        info = create_info(build)
+        info["os_max_ver"] = Firmware.find(1594).firmware_string
+        with create_spk(build, info=info) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert422(response)
+        self.assertIn(
+            "Maximum firmware must be greater than or equal to minimum firmware",
+            response.data.decode(),
+        )
+
+    def test_post_conflict_firmware_max_range_overlap(self):
+        # Two builds with overlapping firmware ranges on the same arch should conflict.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        arch = [Architecture.find("88f628x")]
+        first_build = BuildFactory.build(
+            architectures=arch,
+            firmware_min=Firmware.find(1594),
+            firmware_max=Firmware.find(4458),
+        )
+        with create_spk(first_build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+        # Second build: same arch, firmware range overlaps (min=4458, no max)
+        second_build = BuildFactory.build(
+            version=first_build.version,
+            architectures=arch,
+            firmware_min=Firmware.find(4458),
+            firmware_max=None,
+        )
+        with create_spk(second_build) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert409(response)
+        self.assertIn("Conflicting architectures", response.data.decode())
+
+    def test_post_no_conflict_non_overlapping_firmware_ranges(self):
+        # Two builds on the same arch with non-overlapping firmware ranges are allowed.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        arch = [Architecture.find("88f628x")]
+        first_build = BuildFactory.build(
+            architectures=arch,
+            firmware_min=Firmware.find(1594),
+            firmware_max=Firmware.find(1594),
+        )
+        with create_spk(first_build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+        second_build = BuildFactory.build(
+            version=first_build.version,
+            architectures=arch,
+            firmware_min=Firmware.find(4458),
+            firmware_max=None,
+        )
+        with create_spk(second_build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+    def test_post_unknown_install_dep_service(self):
+        # An unknown install_dep_services value returns 422.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(version__service_dependencies=[])
+        info = create_info(build)
+        info["install_dep_services"] = "no-such-service"
+        with create_spk(build, info=info) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert422(response)
+        self.assertIn(
+            "Unknown dependent service: no-such-service", response.data.decode()
+        )
+
+    def test_post_maintainer_cannot_upload_to_other_package(self):
+        # A maintainer on package A must be rejected when uploading to package B.
+        user = UserFactory(roles=[Role.find("developer")])
+        PackageFactory(
+            maintainers=[user]
+        )  # establishes user as maintainer on a different package
+        package_b = PackageFactory()
+        db.session.commit()
+
+        with create_spk(BuildFactory.build(version__package=package_b)) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert403(response)
+        self.assertIn(
+            "Insufficient permissions on this package", response.data.decode()
+        )

--- a/spkrepo/tests/test_api.py
+++ b/spkrepo/tests/test_api.py
@@ -33,7 +33,8 @@ class PackagesTestCase(BaseTestCase):
         self.assertIs(inserted_build.firmware_min, build.firmware_min)
         self.assertIs(inserted_build.firmware_max, build.firmware_max)
         self.assertIs(inserted_build.publisher, publisher)
-        self.assertEqual(inserted_build.extract_size, build.extract_size)
+        self.assertIsNotNone(inserted_build.size)
+        self.assertGreater(inserted_build.size, 0)
         self.assertAlmostEqual(
             inserted_build.insert_date,
             datetime.now(timezone.utc).replace(microsecond=0, tzinfo=None),
@@ -89,7 +90,10 @@ class PackagesTestCase(BaseTestCase):
         self.assertEqual(
             inserted_build.version.upgrade_wizard, build.version.upgrade_wizard
         )
-        self.assertEqual(inserted_build.version.startable, build.version.startable)
+        self.assertEqual(
+            inserted_build.version.startable,
+            True if build.version.startable is None else build.version.startable,
+        )
         self.assertEqual(inserted_build.version.license, build.version.license)
 
         # manifest

--- a/spkrepo/tests/test_frontend.py
+++ b/spkrepo/tests/test_frontend.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-
 from flask import url_for
 from flask_security import url_for_security
 from lxml.html import fromstring
 
 from spkrepo.ext import db
+from spkrepo.models import Package as PackageModel
+from spkrepo.models import user_datastore
 from spkrepo.tests.common import BaseTestCase, BuildFactory, UserFactory
 
 
@@ -26,8 +27,8 @@ class IndexTestCase(BaseTestCase):
 
 
 class PackagesTestCase(BaseTestCase):
-    # Assert beta is not shown on Packages page
-    def test_get_active_not_stable(self):
+    # Beta packages appear on the Packages page but without a 'beta' label
+    def test_get_active_beta_hides_beta_label(self):
         build = BuildFactory(active=True)
         db.session.commit()
         response = self.client.get(url_for("frontend.packages"))
@@ -39,8 +40,8 @@ class PackagesTestCase(BaseTestCase):
         )
         self.assertNotIn("beta", response_data)
 
-    # Assert package with only inactive version(s) is shown on Packages page
-    def test_get_not_active_not_stable(self):
+    # Inactive beta packages still appear on the Packages page without a 'beta' label
+    def test_get_inactive_beta_hides_beta_label(self):
         build = BuildFactory(active=False)
         db.session.commit()
         response = self.client.get(url_for("frontend.packages"))
@@ -51,6 +52,11 @@ class PackagesTestCase(BaseTestCase):
             response_data,
         )
         self.assertNotIn("beta", response_data)
+
+    def test_get_no_packages(self):
+        # Empty packages list renders 200 with no package entries.
+        response = self.client.get(url_for("frontend.packages"))
+        self.assert200(response)
 
 
 class PackageTestCase(BaseTestCase):
@@ -157,6 +163,14 @@ class PackageTestCase(BaseTestCase):
         response = self.client.get(url_for("frontend.package", name="no-package"))
         self.assert404(response)
 
+    def test_get_package_with_no_versions_returns_404(self):
+        # A Package row that exists but has no versions should return 404.
+        package = PackageModel(name="empty-package")
+        db.session.add(package)
+        db.session.commit()
+        response = self.client.get(url_for("frontend.package", name="empty-package"))
+        self.assert404(response)
+
 
 class ProfileTestCase(BaseTestCase):
     def test_get_anonymous(self):
@@ -178,7 +192,11 @@ class ProfileTestCase(BaseTestCase):
         with self.logged_user("developer", api_key=None):
             response = self.client.get(url_for("frontend.profile"))
             html = fromstring(response.data.decode())
-            self.assertTrue(html.forms[0].fields["api_key"] == "")
+            # Locate the API key form by finding the form that contains the
+            # api_key field, rather than assuming it is always forms[0].
+            api_key_form = next((f for f in html.forms if "api_key" in f.fields), None)
+            self.assertIsNotNone(api_key_form, "API key form not found in page")
+            self.assertEqual(api_key_form.fields["api_key"], "")
 
     def test_post_generate_api_key_developer(self):
         with self.logged_user("developer", api_key=None):
@@ -187,13 +205,43 @@ class ProfileTestCase(BaseTestCase):
             )
             self.assert200(response)
             html = fromstring(response.data.decode())
-            self.assertTrue(html.forms[0].fields["api_key"] != "")
+            api_key_form = next((f for f in html.forms if "api_key" in f.fields), None)
+            self.assertIsNotNone(api_key_form, "API key form not found in page")
+            self.assertNotEqual(api_key_form.fields["api_key"], "")
 
     def test_post_generate_api_key_not_developer(self):
         with self.logged_user(api_key=None):
             response = self.client.post(url_for("frontend.profile"), data=dict())
             self.assert200(response)
             self.assertNotIn("API key", response.data.decode())
+
+    def test_get_existing_api_key_prepopulated(self):
+        # An existing API key should be pre-populated in the form field.
+        with self.logged_user("developer"):
+            response = self.client.get(url_for("frontend.profile"))
+            self.assert200(response)
+            html = fromstring(response.data.decode())
+            api_key_form = next((f for f in html.forms if "api_key" in f.fields), None)
+            self.assertIsNotNone(api_key_form, "API key form not found in page")
+            # The logged developer user has a non-None api_key from the factory
+            self.assertNotEqual(api_key_form.fields["api_key"], "")
+
+    def test_post_generated_api_key_is_64_hex_chars(self):
+        # generate_api_key() uses secrets.token_hex(32) → 64 hex characters.
+        with self.logged_user("developer", api_key=None):
+            response = self.client.post(
+                url_for("frontend.profile"), data=dict(), follow_redirects=True
+            )
+            self.assert200(response)
+            html = fromstring(response.data.decode())
+            api_key_form = next((f for f in html.forms if "api_key" in f.fields), None)
+            self.assertIsNotNone(api_key_form)
+            api_key = api_key_form.fields["api_key"]
+            self.assertRegex(
+                api_key,
+                r"^[0-9a-f]{64}$",
+                "API key should be 64 lowercase hex characters",
+            )
 
 
 class RegisterTestCase(BaseTestCase):
@@ -217,3 +265,30 @@ class RegisterTestCase(BaseTestCase):
         self.client.post(url_for_security("register"), data=data)
         response = self.client.post(url_for_security("register"), data=data)
         self.assertIn("Username already taken", response.data.decode())
+
+    def test_username_too_short(self):
+        # Length(min=4) validator on SpkrepoRegisterForm.username
+        data = dict(
+            username="abc",
+            email="short@gmail.com",
+            password="password",
+            password_confirm="password",
+        )
+        response = self.client.post(url_for_security("register"), data=data)
+        self.assert200(response)
+        self.assertNotIn("Logout", response.data.decode())
+
+    def test_successful_registration(self):
+        data = dict(
+            username="newuser",
+            email="newuser@gmail.com",
+            password="password",
+            password_confirm="password",
+        )
+        response = self.client.post(
+            url_for_security("register"), data=data, follow_redirects=True
+        )
+        self.assert200(response)
+        user = user_datastore.find_user(username="newuser")
+        self.assertIsNotNone(user)
+        self.assertEqual(user.email, "newuser@gmail.com")

--- a/spkrepo/tests/test_frontend.py
+++ b/spkrepo/tests/test_frontend.py
@@ -193,6 +193,7 @@ class ProfileTestCase(BaseTestCase):
         with self.logged_user(api_key=None):
             response = self.client.post(url_for("frontend.profile"), data=dict())
             self.assert200(response)
+            self.assertNotIn("API key", response.data.decode())
 
 
 class RegisterTestCase(BaseTestCase):

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -146,7 +146,6 @@ class CatalogTestCase(BaseTestCase):
         else:
             self.assertNotIn("startable", entry)
 
-
     def test_missing_data_arch(self):
         self.assert400(
             self.client.post(

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -302,26 +302,6 @@ class CatalogTestCase(BaseTestCase):
             packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
-    def test_stable_build_active_stable_no_distributor(self):
-        build = BuildFactory(
-            active=True,
-            version__report_url=None,
-            version__distributor=None,
-            architectures=[Architecture.find("88f6281", syno=True)],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        data = dict(arch="88f6281", build="1594", language="enu")
-        response = self.client.post(url_for("nas.catalog"), data=data)
-        self.assert200(response)
-        self.assertHeader(response, "Content-Type", "application/json")
-        catalog = json.loads(response.data.decode())
-        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
-        self.assertEqual(len(packages), 1)
-        self.assertCatalogEntry(
-            packages[0], build, data, dict(arch="88f628x", build="1594")
-        )
-
     def test_stable_build_active_stable_qinst(self):
         build = BuildFactory(
             active=True,
@@ -343,13 +323,13 @@ class CatalogTestCase(BaseTestCase):
             packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
-    def test_stable_build_active_stable_qstart(self):
+    def test_stable_build_active_stable_qstart_not_startable(self):
         build = BuildFactory(
             active=True,
             version__report_url=None,
             version__license=None,
             version__install_wizard=False,
-            version__startable=None,
+            version__startable=False,
             architectures=[Architecture.find("88f6281", syno=True)],
             firmware_min=Firmware.find(1594),
         )
@@ -491,7 +471,7 @@ class CatalogTestCase(BaseTestCase):
             packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
-    def test_not_stable_build_not_active_stable(self):
+    def test_not_stable_build_not_active_stable_channel(self):
         BuildFactory(
             active=False,
             version__report_url=None,
@@ -526,7 +506,7 @@ class CatalogTestCase(BaseTestCase):
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 0)
 
-    def test_stable_build_not_active_not_stable(self):
+    def test_stable_build_not_active_not_stable_channel(self):
         BuildFactory(
             active=False,
             architectures=[Architecture.find("88f6281", syno=True)],

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -216,8 +216,9 @@ class CatalogTestCase(BaseTestCase):
         self.assertCatalogEntry(packages[0], build, data)
 
     def test_stable_noarch_build_active_stable_dsm6(self):
-        # DSM 6.2 (build 23739): response format has packages + keyrings (>= 5004, < 40000).
-        # firmware_min must also be DSM 6.x so the major filter (startswith("6.")) matches.
+        # DSM 6.2 (build 23739): response format includes packages + keyrings
+        # (build >= 5004, < 40000). firmware_min must also be DSM 6.x so the
+        # major filter (startswith("6.")) matches.
         build = BuildFactory(
             active=True,
             version__report_url=None,
@@ -308,7 +309,8 @@ class CatalogTestCase(BaseTestCase):
         self.assertCatalogEntry(packages[0], build, data)
 
     def test_stable_build_active_stable_quick_flags_all_true(self):
-        # qinst=True, qupgrade=True, qstart=True: license=None, no wizards, startable=True.
+        # qinst=True, qupgrade=True, qstart=True:
+        # license=None, no wizards, startable=True.
         build = BuildFactory(
             active=True,
             version__report_url=None,
@@ -332,7 +334,8 @@ class CatalogTestCase(BaseTestCase):
         self.assertCatalogEntry(entry, build, data)
 
     def test_stable_build_active_stable_qstart_false_when_not_startable(self):
-        # qstart=False when startable=False, even with license=None and no install wizard.
+        # qstart=False when startable=False,
+        # even with license=None and no install wizard.
         build = BuildFactory(
             active=True,
             version__report_url=None,
@@ -558,7 +561,8 @@ class CatalogTestCase(BaseTestCase):
             firmware_min=Firmware.find(4458),
         )
         db.session.commit()
-        # Without override: build=23739 → major=6, package has firmware_min DSM 5 → excluded.
+        # Without override: build=23739 → major=6,
+        # package has firmware_min DSM 5 → excluded.
         data_auto = dict(arch="88f6281", build="23739", language="enu")
         response_auto = self.client.post(url_for("nas.catalog"), data=data_auto)
         self.assert200(response_auto)

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -16,9 +16,8 @@ from spkrepo.tests.common import (
 
 
 class CatalogTestCase(BaseTestCase):
-    def assertCatalogEntry(self, entry, build, data=None, link_params=None):
+    def assertCatalogEntry(self, entry, build, data=None):
         data = data or {}
-        link_params = link_params or {}
 
         # mandatory
         self.assertEqual(entry["package"], build.version.package.name)
@@ -94,10 +93,10 @@ class CatalogTestCase(BaseTestCase):
         else:
             self.assertEqual(entry["snapshot"], [])
 
-        # report_url
+        # report_url / beta
         if build.version.report_url:
-            entry["report_url"] = build.version.report_url
-            entry["beta"] = True
+            self.assertEqual(entry["report_url"], build.version.report_url)
+            self.assertTrue(entry.get("beta"))
         else:
             self.assertNotIn("report_url", entry)
             self.assertNotIn("beta", entry)
@@ -145,6 +144,12 @@ class CatalogTestCase(BaseTestCase):
             )
         else:
             self.assertNotIn("startable", entry)
+
+        # download counts — always present, values verified separately
+        self.assertIn("download_count", entry)
+        self.assertIn("recent_download_count", entry)
+        self.assertIsInstance(entry["download_count"], int)
+        self.assertIsInstance(entry["recent_download_count"], int)
 
     def test_missing_data_arch(self):
         self.assert400(
@@ -204,21 +209,23 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        # DSM 3.x (build < 5004) returns a bare JSON list, not a dict
+        self.assertIsInstance(catalog, list)
+        packages = catalog
         self.assertEqual(len(packages), 1)
-        self.assertCatalogEntry(
-            packages[0], build, data, dict(arch="88f628x", build="1594")
-        )
+        self.assertCatalogEntry(packages[0], build, data)
 
-    def test_stable_noarch_build_active_stable_5004(self):
+    def test_stable_noarch_build_active_stable_dsm6(self):
+        # DSM 6.2 (build 23739): response format has packages + keyrings (>= 5004, < 40000).
+        # firmware_min must also be DSM 6.x so the major filter (startswith("6.")) matches.
         build = BuildFactory(
             active=True,
             version__report_url=None,
             architectures=[Architecture.find("noarch", syno=True)],
-            firmware_min=Firmware.find(1594),
+            firmware_min=Firmware.find(23739),
         )
         db.session.commit()
-        data = dict(arch="88f6281", build="5004", language="enu")
+        data = dict(arch="88f6281", build="23739", language="enu")
         response = self.client.post(url_for("nas.catalog"), data=data)
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
@@ -226,26 +233,26 @@ class CatalogTestCase(BaseTestCase):
         self.assertIn("packages", catalog)
         self.assertIn("keyrings", catalog)
         self.assertEqual(len(catalog["packages"]), 1)
-        self.assertCatalogEntry(
-            catalog["packages"][0], build, data, dict(arch="88f628x", build="5004")
-        )
+        self.assertCatalogEntry(catalog["packages"][0], build, data)
 
-    def test_stable_arch_build_active_stable_5004(self):
-        BuildFactory(
+    def test_stable_arch_build_active_stable_dsm6(self):
+        # DSM 6.2 arch package appears in a DSM 6 query; response includes keyrings.
+        build = BuildFactory(
             active=True,
             version__report_url=None,
             architectures=[Architecture.find("88f6281", syno=True)],
-            firmware_min=Firmware.find(1594),
+            firmware_min=Firmware.find(23739),
         )
         db.session.commit()
-        data = dict(arch="88f6281", build="5004", language="enu")
+        data = dict(arch="88f6281", build="23739", language="enu")
         response = self.client.post(url_for("nas.catalog"), data=data)
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
         self.assertIn("packages", catalog)
         self.assertIn("keyrings", catalog)
-        self.assertEqual(len(catalog["packages"]), 0)
+        self.assertEqual(len(catalog["packages"]), 1)
+        self.assertCatalogEntry(catalog["packages"][0], build, data)
 
     def test_stable_build_active_stable_download_count(self):
         package = PackageFactory()
@@ -298,54 +305,10 @@ class CatalogTestCase(BaseTestCase):
         catalog = json.loads(response.data.decode())
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 1)
-        self.assertCatalogEntry(
-            packages[0], build, data, dict(arch="88f628x", build="1594")
-        )
+        self.assertCatalogEntry(packages[0], build, data)
 
-    def test_stable_build_active_stable_qinst(self):
-        build = BuildFactory(
-            active=True,
-            version__report_url=None,
-            version__license=None,
-            version__install_wizard=False,
-            architectures=[Architecture.find("88f6281", syno=True)],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        data = dict(arch="88f6281", build="1594", language="enu")
-        response = self.client.post(url_for("nas.catalog"), data=data)
-        self.assert200(response)
-        self.assertHeader(response, "Content-Type", "application/json")
-        catalog = json.loads(response.data.decode())
-        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
-        self.assertEqual(len(packages), 1)
-        self.assertCatalogEntry(
-            packages[0], build, data, dict(arch="88f628x", build="1594")
-        )
-
-    def test_stable_build_active_stable_qstart_not_startable(self):
-        build = BuildFactory(
-            active=True,
-            version__report_url=None,
-            version__license=None,
-            version__install_wizard=False,
-            version__startable=False,
-            architectures=[Architecture.find("88f6281", syno=True)],
-            firmware_min=Firmware.find(1594),
-        )
-        db.session.commit()
-        data = dict(arch="88f6281", build="1594", language="enu")
-        response = self.client.post(url_for("nas.catalog"), data=data)
-        self.assert200(response)
-        self.assertHeader(response, "Content-Type", "application/json")
-        catalog = json.loads(response.data.decode())
-        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
-        self.assertEqual(len(packages), 1)
-        self.assertCatalogEntry(
-            packages[0], build, data, dict(arch="88f628x", build="1594")
-        )
-
-    def test_stable_build_active_stable_qstart_startable(self):
+    def test_stable_build_active_stable_quick_flags_all_true(self):
+        # qinst=True, qupgrade=True, qstart=True: license=None, no wizards, startable=True.
         build = BuildFactory(
             active=True,
             version__report_url=None,
@@ -359,13 +322,38 @@ class CatalogTestCase(BaseTestCase):
         data = dict(arch="88f6281", build="1594", language="enu")
         response = self.client.post(url_for("nas.catalog"), data=data)
         self.assert200(response)
-        self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 1)
-        self.assertCatalogEntry(
-            packages[0], build, data, dict(arch="88f628x", build="1594")
+        entry = packages[0]
+        self.assertTrue(entry["qinst"])
+        self.assertTrue(entry["qupgrade"])
+        self.assertTrue(entry["qstart"])
+        self.assertCatalogEntry(entry, build, data)
+
+    def test_stable_build_active_stable_qstart_false_when_not_startable(self):
+        # qstart=False when startable=False, even with license=None and no install wizard.
+        build = BuildFactory(
+            active=True,
+            version__report_url=None,
+            version__license=None,
+            version__install_wizard=False,
+            version__startable=False,
+            architectures=[Architecture.find("88f6281", syno=True)],
+            firmware_min=Firmware.find(1594),
         )
+        db.session.commit()
+        data = dict(arch="88f6281", build="1594", language="enu")
+        response = self.client.post(url_for("nas.catalog"), data=data)
+        self.assert200(response)
+        catalog = json.loads(response.data.decode())
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
+        entry = packages[0]
+        self.assertTrue(entry["qinst"])
+        self.assertTrue(entry["qupgrade"])
+        self.assertFalse(entry["qstart"])
+        self.assertCatalogEntry(entry, build, data)
 
     def test_stable_build_active_stable_different_arch(self):
         BuildFactory(
@@ -399,7 +387,7 @@ class CatalogTestCase(BaseTestCase):
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 0)
 
-    def test_stable_build_not_active_stable(self):
+    def test_stable_channel_excludes_inactive_stable_build(self):
         BuildFactory(
             active=False,
             version__report_url=None,
@@ -415,7 +403,7 @@ class CatalogTestCase(BaseTestCase):
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 0)
 
-    def test_stable_build_active_not_stable(self):
+    def test_stable_channel_excludes_active_beta_build(self):
         BuildFactory(
             active=True,
             architectures=[Architecture.find("88f6281", syno=True)],
@@ -430,7 +418,7 @@ class CatalogTestCase(BaseTestCase):
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 0)
 
-    def test_not_stable_build_active_stable(self):
+    def test_beta_channel_includes_active_stable_build(self):
         build = BuildFactory(
             active=True,
             version__report_url=None,
@@ -447,11 +435,9 @@ class CatalogTestCase(BaseTestCase):
         catalog = json.loads(response.data.decode())
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 1)
-        self.assertCatalogEntry(
-            packages[0], build, data, dict(arch="88f628x", build="1594")
-        )
+        self.assertCatalogEntry(packages[0], build, data)
 
-    def test_not_stable_build_active_not_stable(self):
+    def test_beta_channel_includes_active_beta_build(self):
         build = BuildFactory(
             active=True,
             architectures=[Architecture.find("88f6281", syno=True)],
@@ -467,11 +453,9 @@ class CatalogTestCase(BaseTestCase):
         catalog = json.loads(response.data.decode())
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 1)
-        self.assertCatalogEntry(
-            packages[0], build, data, dict(arch="88f628x", build="1594")
-        )
+        self.assertCatalogEntry(packages[0], build, data)
 
-    def test_not_stable_build_not_active_stable_channel(self):
+    def test_inactive_stable_build_excluded_from_beta_channel(self):
         BuildFactory(
             active=False,
             version__report_url=None,
@@ -489,7 +473,8 @@ class CatalogTestCase(BaseTestCase):
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 0)
 
-    def test_not_stable_build_not_active_not_stable(self):
+    def test_inactive_beta_build_excluded_from_beta_channel(self):
+        # An inactive beta build must not appear even in the beta channel.
         BuildFactory(
             active=False,
             architectures=[Architecture.find("88f6281", syno=True)],
@@ -506,22 +491,125 @@ class CatalogTestCase(BaseTestCase):
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
         self.assertEqual(len(packages), 0)
 
-    def test_stable_build_not_active_not_stable_channel(self):
+    def test_response_format_dsm7_no_keyrings(self):
+        # DSM 7 (build >= 40000): response is {"packages": [...]} with NO keyrings key.
+        build = BuildFactory(
+            active=True,
+            version__report_url=None,
+            architectures=[Architecture.find("88f6281", syno=True)],
+            firmware_min=Firmware.find(42661),
+        )
+        db.session.commit()
+        data = dict(arch="88f6281", build="42661", language="enu")
+        response = self.client.post(url_for("nas.catalog"), data=data)
+        self.assert200(response)
+        self.assertHeader(response, "Content-Type", "application/json")
+        catalog = json.loads(response.data.decode())
+        self.assertIn("packages", catalog)
+        self.assertNotIn("keyrings", catalog)
+        self.assertEqual(len(catalog["packages"]), 1)
+        self.assertCatalogEntry(catalog["packages"][0], build, data)
+
+    def test_beta_package_excluded_for_dsm7(self):
         BuildFactory(
-            active=False,
+            active=True,
+            architectures=[Architecture.find("88f6281", syno=True)],
+            firmware_min=Firmware.find(42661),
+        )
+        db.session.commit()
+        data = dict(
+            arch="88f6281",
+            build="42661",
+            language="enu",
+            package_update_channel="beta",
+        )
+        response = self.client.post(url_for("nas.catalog"), data=data)
+        self.assert200(response)
+        catalog = json.loads(response.data.decode())
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 0)
+
+    def test_stable_package_included_for_dsm7_beta_channel(self):
+        build = BuildFactory(
+            active=True,
+            version__report_url=None,
+            architectures=[Architecture.find("88f6281", syno=True)],
+            firmware_min=Firmware.find(42661),
+        )
+        db.session.commit()
+        data = dict(
+            arch="88f6281",
+            build="42661",
+            language="enu",
+            package_update_channel="beta",
+        )
+        response = self.client.post(url_for("nas.catalog"), data=data)
+        self.assert200(response)
+        catalog = json.loads(response.data.decode())
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
+        self.assertEqual(packages[0]["package"], build.version.package.name)
+
+    def test_explicit_major_parameter_overrides_firmware_table(self):
+        build = BuildFactory(
+            active=True,
+            version__report_url=None,
+            architectures=[Architecture.find("88f6281", syno=True)],
+            firmware_min=Firmware.find(4458),
+        )
+        db.session.commit()
+        # Without override: build=23739 → major=6, package has firmware_min DSM 5 → excluded.
+        data_auto = dict(arch="88f6281", build="23739", language="enu")
+        response_auto = self.client.post(url_for("nas.catalog"), data=data_auto)
+        self.assert200(response_auto)
+        catalog_auto = json.loads(response_auto.data.decode())
+        packages_auto = (
+            catalog_auto["packages"] if isinstance(catalog_auto, dict) else catalog_auto
+        )
+        self.assertEqual(len(packages_auto), 0)
+        # With explicit major=5: overrides the table lookup, package is now included.
+        data_explicit = dict(arch="88f6281", build="23739", language="enu", major="5")
+        response_explicit = self.client.post(url_for("nas.catalog"), data=data_explicit)
+        self.assert200(response_explicit)
+        catalog_explicit = json.loads(response_explicit.data.decode())
+        packages_explicit = (
+            catalog_explicit["packages"]
+            if isinstance(catalog_explicit, dict)
+            else catalog_explicit
+        )
+        self.assertEqual(len(packages_explicit), 1)
+        self.assertEqual(packages_explicit[0]["package"], build.version.package.name)
+
+    def test_invalid_major_parameter_returns_422(self):
+        self.assert422(
+            self.client.post(
+                url_for("nas.catalog"),
+                data=dict(arch="88f6281", build="1594", language="enu", major="abc"),
+            )
+        )
+
+    def test_beta_build_fields_present_in_entry(self):
+        build = BuildFactory(
+            active=True,
             architectures=[Architecture.find("88f6281", syno=True)],
             firmware_min=Firmware.find(1594),
         )
+        # Ensure report_url is set so the build is treated as beta
+        self.assertIsNotNone(build.version.report_url)
         db.session.commit()
         data = dict(
             arch="88f6281", build="1594", language="enu", package_update_channel="beta"
         )
         response = self.client.post(url_for("nas.catalog"), data=data)
         self.assert200(response)
-        self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
         packages = catalog["packages"] if isinstance(catalog, dict) else catalog
-        self.assertEqual(len(packages), 0)
+        self.assertEqual(len(packages), 1)
+        entry = packages[0]
+        self.assertIn("report_url", entry)
+        self.assertEqual(entry["report_url"], build.version.report_url)
+        self.assertIn("beta", entry)
+        self.assertTrue(entry["beta"])
 
 
 class DownloadTestCase(BaseTestCase):
@@ -656,6 +744,30 @@ class DownloadTestCase(BaseTestCase):
                 "nas.download",
                 architecture_id=architecture.id,
                 firmware_build=1593,
+                build_id=build.id,
+            )
+        )
+        self.assert400(response)
+        self.assertEqual(Download.query.count(), 0)
+
+    def test_firmware_build_above_firmware_max(self):
+        architecture = Architecture.find("88f6281", syno=True)
+        firmware_min = Firmware.find(1594)
+        firmware_max = Firmware.find(4458)
+        build = BuildFactory(
+            active=True,
+            version__report_url=None,
+            architectures=[architecture],
+            firmware_min=firmware_min,
+            firmware_max=firmware_max,
+        )
+        db.session.commit()
+        self.assertEqual(Download.query.count(), 0)
+        response = self.client.get(
+            url_for(
+                "nas.download",
+                architecture_id=architecture.id,
+                firmware_build=firmware_max.build + 1,
                 build_id=build.id,
             )
         )

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -76,6 +76,7 @@ class CatalogTestCase(BaseTestCase):
             )
 
         # screenshots
+        self.assertIn("snapshot", entry)
         if build.version.package.screenshots:
             self.assertEqual(
                 entry["snapshot"],
@@ -91,7 +92,7 @@ class CatalogTestCase(BaseTestCase):
                     )
                 )
         else:
-            self.assertNotIn("snapshot", entry)
+            self.assertEqual(entry["snapshot"], [])
 
         # report_url
         if build.version.report_url:
@@ -131,42 +132,20 @@ class CatalogTestCase(BaseTestCase):
         else:
             self.assertNotIn("maintainer_url", entry)
 
-        # depsers
-        if build.version.service_dependencies:
+        # size
+        if build.size:
+            self.assertEqual(entry["size"], build.size)
+        else:
+            self.assertNotIn("size", entry)
+
+        # startable
+        if build.version.startable is not None:
             self.assertEqual(
-                entry["depsers"],
-                " ".join([s.code for s in build.version.service_dependencies]),
+                entry["startable"], "yes" if build.version.startable else "no"
             )
         else:
-            self.assertNotIn("depsers", entry)
+            self.assertNotIn("startable", entry)
 
-        # conf_deppkgs
-        if build.buildmanifest.conf_dependencies:
-            self.assertEqual(
-                entry["conf_deppkgs"], build.buildmanifest.conf_dependencies
-            )
-        else:
-            self.assertNotIn("conf_deppkgs", entry)
-
-        # conf_conxpkgs
-        if build.buildmanifest.conf_conflicts:
-            self.assertEqual(entry["conf_conxpkgs"], build.buildmanifest.conf_conflicts)
-        else:
-            self.assertNotIn("conf_conxpkgs", entry)
-
-        # conf_privilege
-        if build.buildmanifest.conf_privilege:
-            self.assertEqual(
-                entry["conf_privilege"], build.buildmanifest.conf_privilege
-            )
-        else:
-            self.assertNotIn("conf_privilege", entry)
-
-        # conf_resource
-        if build.buildmanifest.conf_resource:
-            self.assertEqual(entry["conf_resource"], build.buildmanifest.conf_resource)
-        else:
-            self.assertNotIn("conf_resource", entry)
 
     def test_missing_data_arch(self):
         self.assert400(
@@ -226,9 +205,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
         self.assertCatalogEntry(
-            catalog[0], build, data, dict(arch="88f628x", build="1594")
+            packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
     def test_stable_noarch_build_active_stable_5004(self):
@@ -290,9 +270,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
-        self.assertEqual(catalog[0]["download_count"], 7)
-        self.assertEqual(catalog[0]["recent_download_count"], 3)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
+        self.assertEqual(packages[0]["download_count"], 7)
+        self.assertEqual(packages[0]["recent_download_count"], 3)
 
     def test_stable_build_active_stable_null_data(self):
         build = BuildFactory(
@@ -316,9 +297,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
         self.assertCatalogEntry(
-            catalog[0], build, data, dict(arch="88f628x", build="1594")
+            packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
     def test_stable_build_active_stable_no_distributor(self):
@@ -335,9 +317,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
         self.assertCatalogEntry(
-            catalog[0], build, data, dict(arch="88f628x", build="1594")
+            packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
     def test_stable_build_active_stable_qinst(self):
@@ -355,9 +338,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
         self.assertCatalogEntry(
-            catalog[0], build, data, dict(arch="88f628x", build="1594")
+            packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
     def test_stable_build_active_stable_qstart(self):
@@ -376,9 +360,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
         self.assertCatalogEntry(
-            catalog[0], build, data, dict(arch="88f628x", build="1594")
+            packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
     def test_stable_build_active_stable_qstart_startable(self):
@@ -397,9 +382,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
         self.assertCatalogEntry(
-            catalog[0], build, data, dict(arch="88f628x", build="1594")
+            packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
     def test_stable_build_active_stable_different_arch(self):
@@ -415,7 +401,8 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 0)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 0)
 
     def test_stable_build_active_stable_different_firmware(self):
         BuildFactory(
@@ -430,7 +417,8 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 0)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 0)
 
     def test_stable_build_not_active_stable(self):
         BuildFactory(
@@ -445,7 +433,8 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 0)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 0)
 
     def test_stable_build_active_not_stable(self):
         BuildFactory(
@@ -459,7 +448,8 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 0)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 0)
 
     def test_not_stable_build_active_stable(self):
         build = BuildFactory(
@@ -476,9 +466,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
         self.assertCatalogEntry(
-            catalog[0], build, data, dict(arch="88f628x", build="1594")
+            packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
     def test_not_stable_build_active_not_stable(self):
@@ -495,9 +486,10 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 1)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 1)
         self.assertCatalogEntry(
-            catalog[0], build, data, dict(arch="88f628x", build="1594")
+            packages[0], build, data, dict(arch="88f628x", build="1594")
         )
 
     def test_not_stable_build_not_active_stable(self):
@@ -515,7 +507,8 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 0)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 0)
 
     def test_not_stable_build_not_active_not_stable(self):
         BuildFactory(
@@ -531,7 +524,8 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 0)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 0)
 
     def test_stable_build_not_active_not_stable(self):
         BuildFactory(
@@ -547,7 +541,8 @@ class CatalogTestCase(BaseTestCase):
         self.assert200(response)
         self.assertHeader(response, "Content-Type", "application/json")
         catalog = json.loads(response.data.decode())
-        self.assertEqual(len(catalog), 0)
+        packages = catalog["packages"] if isinstance(catalog, dict) else catalog
+        self.assertEqual(len(packages), 0)
 
 
 class DownloadTestCase(BaseTestCase):

--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -403,6 +403,8 @@ def populate_db():
             [
                 {"version": "3.1", "build": 1594, "type": "dsm"},
                 {"version": "5.0", "build": 4458, "type": "dsm"},
+                {"version": "6.2", "build": 23739, "type": "dsm"},
+                {"version": "7.1", "build": 42661, "type": "dsm"},
             ]
         )
     )

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -1186,17 +1186,62 @@ class IndexView(AdminIndexView):
             return redirect(url_for("security.login"))
         if not any(map(current_user.has_role, ("developer", "package_admin", "admin"))):
             abort(403)
+
+        is_privileged = current_user.has_role("package_admin") or current_user.has_role("admin")
+
+        if is_privileged:
+            package_count = Package.query.count()
+            build_count = Build.query.count()
+            inactive_build_count = Build.query.filter_by(active=False).count()
+            recent_versions = (
+                Version.query
+                .order_by(Version.insert_date.desc())
+                .limit(5)
+                .all()
+            )
+        else:
+            package_count = (
+                Package.query
+                .join(Package.maintainers)
+                .filter(User.id == current_user.id)
+                .count()
+            )
+            build_count = (
+                Build.query
+                .join(Build.version)
+                .join(Version.package)
+                .join(Package.maintainers)
+                .filter(User.id == current_user.id)
+                .count()
+            )
+            inactive_build_count = (
+                Build.query
+                .filter_by(active=False)
+                .join(Build.version)
+                .join(Version.package)
+                .join(Package.maintainers)
+                .filter(User.id == current_user.id)
+                .count()
+            )
+            recent_versions = (
+                Version.query
+                .join(Version.package)
+                .join(Package.maintainers)
+                .filter(User.id == current_user.id)
+                .order_by(Version.insert_date.desc())
+                .limit(5)
+                .all()
+            )
+
         return self.render(
             "admin/index.html",
-            package_count=Package.query.count(),
-            build_count=Build.query.count(),
-            inactive_build_count=Build.query.filter_by(active=False).count(),
+            package_count=package_count,
+            build_count=build_count,
+            inactive_build_count=inactive_build_count,
             unconfirmed_user_count=(
                 User.query.filter_by(confirmed_at=None).count()
                 if current_user.has_role("admin")
                 else None
             ),
-            recent_versions=Version.query.order_by(Version.insert_date.desc())
-            .limit(5)
-            .all(),
+            recent_versions=recent_versions,
         )

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -35,6 +35,13 @@ from ..models import (
 from ..utils import SPK
 
 
+def _bool_formatter(v, c, m, p):
+    value = getattr(m, p)
+    if value:
+        return Markup('<i class="fa fa-check-circle" style="color: #27ae60;"></i>')
+    return Markup('<i class="fa fa-times-circle" style="color: #e74c3c;"></i>')
+
+
 class UserView(ModelView):
     """View for :class:`~spkrepo.models.User`"""
 
@@ -260,11 +267,9 @@ def _apply_info_from_spk(session, build, spk, md5_hash):
     version.install_wizard = "install" in spk.wizards
     version.upgrade_wizard = "upgrade" in spk.wizards
 
-    startable = None
+    startable = True  # default per Synology docs
     if info.get("startable") is False or info.get("ctl_stop") is False:
         startable = False
-    elif info.get("startable") is True or info.get("ctl_stop") is True:
-        startable = True
     version.startable = startable
 
     version.license = spk.license
@@ -381,6 +386,17 @@ def _apply_info_from_spk(session, build, spk, md5_hash):
     session.flush()
 
 
+def _resync_build_file(build):
+    """Recalculate md5 and size from the build file on disk."""
+    if not build.path:
+        raise ValueError("Build has no file path")
+    file_path = os.path.join(current_app.config["DATA_PATH"], build.path)
+    if not os.path.exists(file_path):
+        raise ValueError("Build file missing on disk")
+    build.md5 = build.calculate_md5()
+    build.size = os.path.getsize(file_path)
+
+
 def _resync_build_metadata(session, build):
     if not build.path:
         raise ValueError("Build has no file path")
@@ -444,16 +460,36 @@ class PackageView(ModelView):
             shutil.rmtree(package_path)
 
     # View
-    column_list = ("name", "author", "maintainers", "insert_date")
+    column_list = (
+        "name",
+        "author",
+        "maintainers",
+        "download_count",
+        "recent_download_count",
+        "insert_date",
+    )
     column_sortable_list = (
         ("name", "name"),
         ("author", "author.username"),
         ("insert_date", "insert_date"),
+        ("download_count", "download_count"),
+        ("recent_download_count", "recent_download_count"),
     )
-
     column_formatters = {
-        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S")
+        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
+        "download_count": lambda v, c, m, p: (
+            f"{m.download_count:,}" if m.download_count else "0"
+        ),
+        "recent_download_count": lambda v, c, m, p: (
+            f"{m.recent_download_count:,}" if m.recent_download_count else "0"
+        ),
     }
+    column_labels = {
+        "download_count": "Downloads",
+        "recent_download_count": "Recent Downloads",
+        "author.username": "Author",
+    }
+    column_filters = ("name", "author.username")
 
     # Form
     form_columns = ("name", "author", "maintainers")
@@ -492,6 +528,10 @@ class VersionView(ModelView):
     def can_resync_info(self):
         return current_user.has_role("admin")
 
+    @property
+    def can_resync_file(self):
+        return current_user.has_role("admin")
+
     # Hooks
     def on_model_delete(self, model):
         version_path = os.path.join(
@@ -506,18 +546,19 @@ class VersionView(ModelView):
         "upstream_version",
         "version",
         "beta",
-        "service_dependencies",
-        "insert_date",
+        "startable",
         "all_builds_active",
         "install_wizard",
         "upgrade_wizard",
-        "startable",
+        "insert_date",
     )
     column_labels = {
         "package.name": "Package Name",
         "version_string": "Version",
         "dependencies": "Dependencies",
-        "service_dependencies": "Services",
+        "all_builds_active": "All Active",
+        "install_wizard": "Install Wizard",
+        "upgrade_wizard": "Upgrade Wizard",
     }
     column_filters = (
         "package.name",
@@ -525,6 +566,7 @@ class VersionView(ModelView):
         "version",
         "beta",
         "all_builds_active",
+        "startable",
     )
     column_sortable_list = (
         ("package", "package.name"),
@@ -539,7 +581,12 @@ class VersionView(ModelView):
     )
 
     column_formatters = {
-        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S")
+        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
+        "all_builds_active": _bool_formatter,
+        "install_wizard": _bool_formatter,
+        "upgrade_wizard": _bool_formatter,
+        "startable": _bool_formatter,
+        "beta": _bool_formatter,
     }
     column_default_sort = (Version.insert_date, True)
 
@@ -637,7 +684,7 @@ class VersionView(ModelView):
                                 current_app.config["GNUPG_TIMESTAMP_URL"],
                                 current_app.config["GNUPG_PATH"],
                             )
-                            build.md5 = spk.calculate_md5()
+                            _resync_build_file(build)
                             self.session.commit()
                             success.append(filename)
                         except Exception:
@@ -694,7 +741,7 @@ class VersionView(ModelView):
                             continue
                         try:
                             spk.unsign()
-                            build.md5 = spk.calculate_md5()
+                            _resync_build_file(build)
                             self.session.commit()
                             success.append(filename)
                         except Exception:
@@ -734,7 +781,7 @@ class VersionView(ModelView):
 
     @action(
         "resync_info",
-        "Resync INFO",
+        "Resync Info",
         "Reapply INFO metadata from builds on selected versions?",
     )
     def action_resync_info(self, ids):
@@ -778,8 +825,52 @@ class VersionView(ModelView):
                     "error",
                 )
 
+    @action(
+        "resync_file",
+        "Resync File",
+        "Recalculate md5 and size from build files on selected versions?",
+    )
+    def action_resync_file(self, ids):
+        successes = []
+        failures = []
+
+        versions = get_query_for_ids(self.get_query(), self.model, ids).all()
+        for version in versions:
+            for build in version.builds:
+                filename = os.path.basename(build.path) if build.path else str(build.id)
+                try:
+                    _resync_build_file(build)
+                    self.session.commit()
+                    successes.append(filename)
+                except Exception as exc:
+                    self.session.rollback()
+                    failures.append((filename, str(exc)))
+
+        if successes:
+            if len(successes) == 1:
+                flash(f"Build {successes[0]} file data refreshed.")
+            else:
+                success_list = ", ".join(successes)
+                flash(
+                    f"Refreshed file data for {len(successes)} builds: {success_list}"
+                )
+
+        if failures:
+            if len(failures) == 1:
+                name, message = failures[0]
+                flash(f"Failed to resync build {name}: {message}", "error")
+            else:
+                failure_list = "; ".join(
+                    f"{name}: {message}" for name, message in failures
+                )
+                flash(
+                    f"Failed to resync {len(failures)} builds: {failure_list}", "error"
+                )
+
     def is_action_allowed(self, name):
         if name == "resync_info" and not self.can_resync_info:
+            return False
+        if name == "resync_file" and not self.can_resync_file:
             return False
         if name == "sign" and not self.can_sign:
             return False
@@ -791,6 +882,8 @@ class VersionView(ModelView):
     def handle_action(self, return_view=None):
         action = request.form.get("action")
         if action == "resync_info" and not self.can_resync_info:
+            abort(403)
+        if action == "resync_file" and not self.can_resync_file:
             abort(403)
         return super(VersionView, self).handle_action(return_view)
 
@@ -827,6 +920,10 @@ class BuildView(ModelView):
     def can_resync_info(self):
         return current_user.has_role("admin")
 
+    @property
+    def can_resync_file(self):
+        return current_user.has_role("admin")
+
     # View
     column_list = (
         "version.package",
@@ -835,9 +932,10 @@ class BuildView(ModelView):
         "architectures",
         "firmware_min",
         "firmware_max",
+        "size",
+        "active",
         "publisher",
         "insert_date",
-        "active",
     )
     column_labels = {
         "version.package": "Package",
@@ -848,6 +946,7 @@ class BuildView(ModelView):
         "firmware_min.version": "Minimum Firmware Version",
         "firmware_max.version": "Maximum Firmware Version",
         "publisher.username": "Publisher Username",
+        "size": "Size",
     }
     column_filters = (
         "version.package.name",
@@ -858,6 +957,7 @@ class BuildView(ModelView):
         "firmware_max.version",
         "publisher.username",
         "active",
+        "size",
     )
     column_sortable_list = (
         ("version.package", "version.package.name"),
@@ -868,10 +968,15 @@ class BuildView(ModelView):
         ("publisher", "publisher.username"),
         ("insert_date", "insert_date"),
         ("active", "active"),
+        ("size", "size"),
     )
 
     column_formatters = {
-        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S")
+        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
+        "size": lambda v, c, m, p: (
+            f"{m.size / 1024 / 1024:.1f} MB" if m.size else None
+        ),
+        "active": _bool_formatter,
     }
     column_default_sort = (Build.insert_date, True)
 
@@ -966,7 +1071,7 @@ class BuildView(ModelView):
                             current_app.config["GNUPG_TIMESTAMP_URL"],
                             current_app.config["GNUPG_PATH"],
                         )
-                        build.md5 = spk.calculate_md5()
+                        _resync_build_file(build)
                         self.session.commit()
                         success.append(filename)
                     except Exception:
@@ -1017,7 +1122,7 @@ class BuildView(ModelView):
                         continue
                     try:
                         spk.unsign()
-                        build.md5 = spk.calculate_md5()
+                        _resync_build_file(build)
                         self.session.commit()
                         success.append(filename)
                     except Exception:
@@ -1054,7 +1159,7 @@ class BuildView(ModelView):
 
     @action(
         "resync_info",
-        "Resync INFO",
+        "Resync Info",
         "Reapply INFO metadata from selected builds?",
     )
     def action_resync_info(self, ids):
@@ -1104,8 +1209,58 @@ class BuildView(ModelView):
                     "error",
                 )
 
+    @action(
+        "resync_file",
+        "Resync File",
+        "Recalculate md5 and size from selected build files?",
+    )
+    def action_resync_file(self, ids):
+        successes = []
+        failures = []
+
+        for build_id in ids:
+            try:
+                build = self.session.get(self.model, int(build_id))
+            except (TypeError, ValueError):
+                continue
+
+            if build is None:
+                continue
+
+            filename = os.path.basename(build.path) if build.path else str(build_id)
+            try:
+                _resync_build_file(build)
+                self.session.commit()
+                successes.append(filename)
+            except Exception as exc:
+                self.session.rollback()
+                failures.append((filename, str(exc)))
+
+        if successes:
+            if len(successes) == 1:
+                flash(f"Build {successes[0]} file data refreshed.")
+            else:
+                success_list = ", ".join(successes)
+                flash(
+                    f"Refreshed file data for {len(successes)} builds: {success_list}"
+                )
+
+        if failures:
+            if len(failures) == 1:
+                name, message = failures[0]
+                flash(f"Failed to resync build {name}: {message}", "error")
+            else:
+                failure_list = "; ".join(
+                    f"{name}: {message}" for name, message in failures
+                )
+                flash(
+                    f"Failed to resync {len(failures)} builds: {failure_list}", "error"
+                )
+
     def is_action_allowed(self, name):
         if name == "resync_info" and not self.can_resync_info:
+            return False
+        if name == "resync_file" and not self.can_resync_file:
             return False
         if name == "sign" and not self.can_sign:
             return False
@@ -1117,6 +1272,8 @@ class BuildView(ModelView):
     def handle_action(self, return_view=None):
         action = request.form.get("action")
         if action == "resync_info" and not self.can_resync_info:
+            abort(403)
+        if action == "resync_file" and not self.can_resync_file:
             abort(403)
         return super(BuildView, self).handle_action(return_view)
 

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -1187,36 +1187,32 @@ class IndexView(AdminIndexView):
         if not any(map(current_user.has_role, ("developer", "package_admin", "admin"))):
             abort(403)
 
-        is_privileged = current_user.has_role("package_admin") or current_user.has_role("admin")
+        is_privileged = current_user.has_role("package_admin") or current_user.has_role(
+            "admin"
+        )
 
         if is_privileged:
             package_count = Package.query.count()
             build_count = Build.query.count()
             inactive_build_count = Build.query.filter_by(active=False).count()
             recent_versions = (
-                Version.query
-                .order_by(Version.insert_date.desc())
-                .limit(5)
-                .all()
+                Version.query.order_by(Version.insert_date.desc()).limit(5).all()
             )
         else:
             package_count = (
-                Package.query
-                .join(Package.maintainers)
+                Package.query.join(Package.maintainers)
                 .filter(User.id == current_user.id)
                 .count()
             )
             build_count = (
-                Build.query
-                .join(Build.version)
+                Build.query.join(Build.version)
                 .join(Version.package)
                 .join(Package.maintainers)
                 .filter(User.id == current_user.id)
                 .count()
             )
             inactive_build_count = (
-                Build.query
-                .filter_by(active=False)
+                Build.query.filter_by(active=False)
                 .join(Build.version)
                 .join(Version.package)
                 .join(Package.maintainers)
@@ -1224,8 +1220,7 @@ class IndexView(AdminIndexView):
                 .count()
             )
             recent_versions = (
-                Version.query
-                .join(Version.package)
+                Version.query.join(Version.package)
                 .join(Package.maintainers)
                 .filter(User.id == current_user.id)
                 .order_by(Version.insert_date.desc())

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -394,7 +394,7 @@ def _resync_build_file(build):
     if not os.path.exists(file_path):
         raise ValueError("Build file missing on disk")
     build.md5 = build.calculate_md5()
-    build.size = os.path.getsize(file_path)
+    build.size = build.calculate_size()
 
 
 def _resync_build_metadata(session, build):

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -564,7 +564,7 @@ class VersionView(ModelView):
             return text
         escaped = Markup.escape(text)
         if len(text) > 250:
-            return Markup(f'{escaped[:250]}...')
+            return Markup(f"{escaped[:250]}...")
         return escaped
 
     # View

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -512,6 +512,8 @@ class VersionView(ModelView):
 
     can_edit = False
 
+    can_view_details = True
+
     @property
     def can_delete(self):
         return current_user.has_role("admin")
@@ -540,6 +542,16 @@ class VersionView(ModelView):
         if os.path.exists(version_path):
             shutil.rmtree(version_path)
 
+    # Define a formatter to truncate long text
+    def _truncate_formatter(view, context, model, name):
+        text = getattr(model, name)
+        if not text:
+            return text
+        escaped = Markup.escape(text)
+        if len(text) > 250:
+            return Markup(f'<span title="{name}">{escaped[:250]}...</span>')
+        return escaped
+
     # View
     column_list = (
         "package",
@@ -548,8 +560,7 @@ class VersionView(ModelView):
         "beta",
         "startable",
         "all_builds_active",
-        "install_wizard",
-        "upgrade_wizard",
+        "total_size",
         "insert_date",
     )
     column_labels = {
@@ -559,14 +570,15 @@ class VersionView(ModelView):
         "all_builds_active": "All Active",
         "install_wizard": "Install Wizard",
         "upgrade_wizard": "Upgrade Wizard",
+        "total_size": "Total Size",
     }
     column_filters = (
         "package.name",
         "upstream_version",
         "version",
         "beta",
-        "all_builds_active",
         "startable",
+        "all_builds_active",
     )
     column_sortable_list = (
         ("package", "package.name"),
@@ -575,8 +587,6 @@ class VersionView(ModelView):
         ("beta", "beta"),
         ("insert_date", "insert_date"),
         ("all_builds_active", "all_builds_active"),
-        ("install_wizard", "install_wizard"),
-        ("upgrade_wizard", "upgrade_wizard"),
         ("startable", "startable"),
     )
 
@@ -587,6 +597,12 @@ class VersionView(ModelView):
         "upgrade_wizard": _bool_formatter,
         "startable": _bool_formatter,
         "beta": _bool_formatter,
+        "total_size": lambda v, c, m, p: (
+            f"{m.total_size / 1024 / 1024:.1f} MB" if m.total_size else None
+        ),
+    }
+    column_formatters_detail = {
+        'license': _truncate_formatter
     }
     column_default_sort = (Version.insert_date, True)
 
@@ -904,6 +920,8 @@ class BuildView(ModelView):
 
     can_edit = False
 
+    can_view_details = True
+
     @property
     def can_delete(self):
         return current_user.has_role("admin")
@@ -927,15 +945,12 @@ class BuildView(ModelView):
     # View
     column_list = (
         "version.package",
-        "version.upstream_version",
         "version.version",
         "architectures",
         "firmware_min",
         "firmware_max",
         "size",
         "active",
-        "publisher",
-        "insert_date",
     )
     column_labels = {
         "version.package": "Package",
@@ -943,30 +958,27 @@ class BuildView(ModelView):
         "version.upstream_version": "Upstream Version",
         "version.version": "Version",
         "architectures.code": "Architecture",
-        "firmware_min.version": "Minimum Firmware Version",
-        "firmware_max.version": "Maximum Firmware Version",
+        "firmware_min.version": "Minimum Firmware",
+        "firmware_max.version": "Maximum Firmware",
         "publisher.username": "Publisher Username",
-        "size": "Size",
+        "size": "Package Size",
+        "checksum": "Application Checksum",
+        "md5": "Package Checksum",
     }
     column_filters = (
         "version.package.name",
-        "version.upstream_version",
         "version.version",
         "architectures.code",
         "firmware_min.version",
         "firmware_max.version",
-        "publisher.username",
-        "active",
         "size",
+        "active",
     )
     column_sortable_list = (
         ("version.package", "version.package.name"),
-        ("version.upstream_version", "version.upstream_version"),
         ("version.version", "version.version"),
         ("firmware_min", "firmware_min.build"),
         ("firmware_max", "firmware_max.build"),
-        ("publisher", "publisher.username"),
-        ("insert_date", "insert_date"),
         ("active", "active"),
         ("size", "size"),
     )

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -1191,6 +1191,12 @@ class IndexView(AdminIndexView):
             package_count=Package.query.count(),
             build_count=Build.query.count(),
             inactive_build_count=Build.query.filter_by(active=False).count(),
-            unconfirmed_user_count=User.query.filter_by(confirmed_at=None).count() if current_user.has_role("admin") else None,
-            recent_versions=Version.query.order_by(Version.insert_date.desc()).limit(5).all(),
+            unconfirmed_user_count=(
+                User.query.filter_by(confirmed_at=None).count()
+                if current_user.has_role("admin")
+                else None
+            ),
+            recent_versions=Version.query.order_by(Version.insert_date.desc())
+            .limit(5)
+            .all(),
         )

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -1186,4 +1186,11 @@ class IndexView(AdminIndexView):
             return redirect(url_for("security.login"))
         if not any(map(current_user.has_role, ("developer", "package_admin", "admin"))):
             abort(403)
-        return super(IndexView, self).index()
+        return self.render(
+            "admin/index.html",
+            package_count=Package.query.count(),
+            build_count=Build.query.count(),
+            inactive_build_count=Build.query.filter_by(active=False).count(),
+            unconfirmed_user_count=User.query.filter_by(confirmed_at=None).count() if current_user.has_role("admin") else None,
+            recent_versions=Version.query.order_by(Version.insert_date.desc()).limit(5).all(),
+        )

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -593,15 +593,18 @@ class VersionView(ModelView):
     column_formatters = {
         "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
         "all_builds_active": _bool_formatter,
-        "install_wizard": _bool_formatter,
-        "upgrade_wizard": _bool_formatter,
         "startable": _bool_formatter,
         "beta": _bool_formatter,
         "total_size": lambda v, c, m, p: (
             f"{m.total_size / 1024 / 1024:.1f} MB" if m.total_size else None
         ),
     }
-    column_formatters_detail = {"license": _truncate_formatter}
+    column_formatters_detail = {
+        "install_wizard": _bool_formatter,
+        "upgrade_wizard": _bool_formatter,
+        "startable": _bool_formatter,
+        "license": _truncate_formatter,
+    }
     column_default_sort = (Version.insert_date, True)
 
     # Custom queries

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -37,9 +37,30 @@ from ..utils import SPK
 
 def _bool_formatter(v, c, m, p):
     value = getattr(m, p)
+    if value is None:
+        return Markup('<i class="fa fa-question-circle" style="color: #aaaaaa;"></i>')
     if value:
         return Markup('<i class="fa fa-check-circle" style="color: #27ae60;"></i>')
     return Markup('<i class="fa fa-times-circle" style="color: #e74c3c;"></i>')
+
+
+def _flash_action_results(successes, failures, skipped=None, item_label="item"):
+    if successes:
+        count = len(successes)
+        flash(
+            f"{item_label.capitalize()} {successes[0]} refreshed."
+            if count == 1
+            else f"Refreshed {count} {item_label}s: {', '.join(successes)}"
+        )
+    if skipped:
+        count = len(skipped)
+        flash(
+            f"{item_label.capitalize()} {skipped[0]} skipped."
+            if count == 1
+            else f"Skipped {count} {item_label}s: {', '.join(skipped)}"
+        )
+    for name, message in failures:
+        flash(f"Failed to process {name}: {message}", "error")
 
 
 class UserView(ModelView):
@@ -390,9 +411,6 @@ def _resync_build_file(build):
     """Recalculate md5 and size from the build file on disk."""
     if not build.path:
         raise ValueError("Build has no file path")
-    file_path = os.path.join(current_app.config["DATA_PATH"], build.path)
-    if not os.path.exists(file_path):
-        raise ValueError("Build file missing on disk")
     build.md5 = build.calculate_md5()
     build.size = build.calculate_size()
 
@@ -402,9 +420,6 @@ def _resync_build_metadata(session, build):
         raise ValueError("Build has no file path")
 
     file_path = os.path.join(current_app.config["DATA_PATH"], build.path)
-    if not os.path.exists(file_path):
-        raise ValueError("Build file missing on disk")
-
     with io.open(file_path, "rb") as stream:
         spk = SPK(stream)
         md5 = spk.calculate_md5()
@@ -549,7 +564,7 @@ class VersionView(ModelView):
             return text
         escaped = Markup.escape(text)
         if len(text) > 250:
-            return Markup(f'<span title="{name}">{escaped[:250]}...</span>')
+            return Markup(f'{escaped[:250]}...')
         return escaped
 
     # View
@@ -658,7 +673,7 @@ class VersionView(ModelView):
     @action(
         "deactivate",
         "Deactivate",
-        "Are you sure you want to deactivate selected  versions' builds?",
+        "Are you sure you want to deactivate selected versions' builds?",
     )
     def action_deactivate(self, ids):
         try:
@@ -707,35 +722,12 @@ class VersionView(ModelView):
                         except Exception:
                             self.session.rollback()
                             failed.append(filename)
-                if failed:
-                    if len(failed) == 1:
-                        flash(f"Failed to sign build {failed[0]}", "error")
-                    else:
-                        failed_list = ", ".join(failed)
-                        flash(
-                            f"Failed to sign {len(failed)} builds: {failed_list}",
-                            "error",
-                        )
-                if already_signed:
-                    if len(already_signed) == 1:
-                        flash(f"Build {already_signed[0]} already signed", "info")
-                    else:
-                        already_list = ", ".join(already_signed)
-                        flash(
-                            (
-                                f"{len(already_signed)} builds already signed: "
-                                f"{already_list}"
-                            ),
-                            "info",
-                        )
-                if success:
-                    if len(success) == 1:
-                        flash(f"Build {success[0]} successfully signed")
-                    else:
-                        success_list = ", ".join(success)
-                        flash(
-                            f"Successfully signed {len(success)} builds: {success_list}"
-                        )
+            _flash_action_results(
+                success,
+                [(f, "") for f in failed],
+                skipped=already_signed,
+                item_label="build",
+            )
         except Exception as e:  # pragma: no cover
             flash(f"Failed to sign builds. {e}", "error")
 
@@ -764,35 +756,12 @@ class VersionView(ModelView):
                         except Exception:
                             self.session.rollback()
                             failed.append(filename)
-                if failed:
-                    if len(failed) == 1:
-                        flash(f"Failed to unsign build {failed[0]}", "error")
-                    else:
-                        failed_list = ", ".join(failed)
-                        flash(
-                            f"Failed to unsign {len(failed)} builds: {failed_list}",
-                            "error",
-                        )
-                if not_signed:
-                    if len(not_signed) == 1:
-                        flash(f"Build {not_signed[0]} not signed", "info")
-                    else:
-                        not_signed_list = ", ".join(not_signed)
-                        flash(
-                            f"{len(not_signed)} builds not signed: {not_signed_list}",
-                            "info",
-                        )
-                if success:
-                    if len(success) == 1:
-                        flash(f"Build {success[0]} successfully unsigned")
-                    else:
-                        success_list = ", ".join(success)
-                        flash(
-                            (
-                                f"Successfully unsigned {len(success)} builds: "
-                                f"{success_list}"
-                            )
-                        )
+            _flash_action_results(
+                success,
+                [(f, "") for f in failed],
+                skipped=not_signed,
+                item_label="build",
+            )
         except Exception as e:  # pragma: no cover
             flash(f"Failed to unsign builds. {e}", "error")
 
@@ -817,30 +786,7 @@ class VersionView(ModelView):
                     self.session.rollback()
                     failures.append((filename, str(exc)))
 
-        if successes:
-            if len(successes) == 1:
-                flash(f"Build {successes[0]} metadata refreshed from INFO.")
-            else:
-                success_list = ", ".join(successes)
-                flash(
-                    (
-                        f"Refreshed metadata from INFO for {len(successes)} builds: "
-                        f"{success_list}"
-                    )
-                )
-
-        if failures:
-            if len(failures) == 1:
-                name, message = failures[0]
-                flash(f"Failed to resync build {name}: {message}", "error")
-            else:
-                failure_list = "; ".join(
-                    f"{name}: {message}" for name, message in failures
-                )
-                flash(
-                    f"Failed to resync {len(failures)} builds: {failure_list}",
-                    "error",
-                )
+        _flash_action_results(successes, failures, item_label="build")
 
     @action(
         "resync_file",
@@ -863,26 +809,7 @@ class VersionView(ModelView):
                     self.session.rollback()
                     failures.append((filename, str(exc)))
 
-        if successes:
-            if len(successes) == 1:
-                flash(f"Build {successes[0]} file data refreshed.")
-            else:
-                success_list = ", ".join(successes)
-                flash(
-                    f"Refreshed file data for {len(successes)} builds: {success_list}"
-                )
-
-        if failures:
-            if len(failures) == 1:
-                name, message = failures[0]
-                flash(f"Failed to resync build {name}: {message}", "error")
-            else:
-                failure_list = "; ".join(
-                    f"{name}: {message}" for name, message in failures
-                )
-                flash(
-                    f"Failed to resync {len(failures)} builds: {failure_list}", "error"
-                )
+        _flash_action_results(successes, failures, item_label="build")
 
     def is_action_allowed(self, name):
         if name == "resync_info" and not self.can_resync_info:
@@ -1090,30 +1017,12 @@ class BuildView(ModelView):
                     except Exception:
                         self.session.rollback()
                         failed.append(filename)
-            if failed:
-                if len(failed) == 1:
-                    flash(f"Failed to sign build {failed[0]}", "error")
-                else:
-                    failed_list = ", ".join(failed)
-                    flash(
-                        f"Failed to sign {len(failed)} builds: {failed_list}",
-                        "error",
-                    )
-            if already_signed:
-                if len(already_signed) == 1:
-                    flash(f"Build {already_signed[0]} already signed", "info")
-                else:
-                    already_list = ", ".join(already_signed)
-                    flash(
-                        f"{len(already_signed)} builds already signed: {already_list}",
-                        "info",
-                    )
-            if success:
-                if len(success) == 1:
-                    flash(f"Build {success[0]} successfully signed")
-                else:
-                    success_list = ", ".join(success)
-                    flash(f"Successfully signed {len(success)} builds: {success_list}")
+            _flash_action_results(
+                success,
+                [(f, "") for f in failed],
+                skipped=already_signed,
+                item_label="build",
+            )
         except Exception as e:  # pragma: no cover
             flash(f"Failed to sign builds. {e}", "error")
 
@@ -1141,32 +1050,12 @@ class BuildView(ModelView):
                     except Exception:
                         self.session.rollback()
                         failed.append(filename)
-            if failed:
-                if len(failed) == 1:
-                    flash(f"Failed to unsign build {failed[0]}", "error")
-                else:
-                    failed_list = ", ".join(failed)
-                    flash(
-                        f"Failed to unsign {len(failed)} builds: {failed_list}",
-                        "error",
-                    )
-            if not_signed:
-                if len(not_signed) == 1:
-                    flash(f"Build {not_signed[0]} not signed", "info")
-                else:
-                    not_signed_list = ", ".join(not_signed)
-                    flash(
-                        f"{len(not_signed)} builds not signed: {not_signed_list}",
-                        "info",
-                    )
-            if success:
-                if len(success) == 1:
-                    flash(f"Build {success[0]} successfully unsigned")
-                else:
-                    success_list = ", ".join(success)
-                    flash(
-                        f"Successfully unsigned {len(success)} builds: {success_list}"
-                    )
+            _flash_action_results(
+                success,
+                [(f, "") for f in failed],
+                skipped=not_signed,
+                item_label="build",
+            )
         except Exception as e:  # pragma: no cover
             flash(f"Failed to unsign builds. {e}", "error")
 
@@ -1197,30 +1086,7 @@ class BuildView(ModelView):
                 self.session.rollback()
                 failures.append((filename, str(exc)))
 
-        if successes:
-            if len(successes) == 1:
-                flash(f"Build {successes[0]} metadata refreshed from INFO.")
-            else:
-                success_list = ", ".join(successes)
-                flash(
-                    (
-                        f"Refreshed metadata from INFO for {len(successes)} builds: "
-                        f"{success_list}"
-                    )
-                )
-
-        if failures:
-            if len(failures) == 1:
-                name, message = failures[0]
-                flash(f"Failed to resync build {name}: {message}", "error")
-            else:
-                failure_list = "; ".join(
-                    f"{name}: {message}" for name, message in failures
-                )
-                flash(
-                    f"Failed to resync {len(failures)} builds: {failure_list}",
-                    "error",
-                )
+        _flash_action_results(successes, failures, item_label="build")
 
     @action(
         "resync_file",
@@ -1249,26 +1115,7 @@ class BuildView(ModelView):
                 self.session.rollback()
                 failures.append((filename, str(exc)))
 
-        if successes:
-            if len(successes) == 1:
-                flash(f"Build {successes[0]} file data refreshed.")
-            else:
-                success_list = ", ".join(successes)
-                flash(
-                    f"Refreshed file data for {len(successes)} builds: {success_list}"
-                )
-
-        if failures:
-            if len(failures) == 1:
-                name, message = failures[0]
-                flash(f"Failed to resync build {name}: {message}", "error")
-            else:
-                failure_list = "; ".join(
-                    f"{name}: {message}" for name, message in failures
-                )
-                flash(
-                    f"Failed to resync {len(failures)} builds: {failure_list}", "error"
-                )
+        _flash_action_results(successes, failures, item_label="build")
 
     def is_action_allowed(self, name):
         if name == "resync_info" and not self.can_resync_info:

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -101,9 +101,10 @@ class UserView(ModelView):
                 if len(users) == 1
                 else f"{len(users)} users were successfully activated."
             )
-        except Exception as e:  # pragma: no cover
+        except Exception:  # pragma: no cover
             self.session.rollback()
-            flash(f"Failed to activate users. {e}", "error")
+            current_app.logger.exception("Failed to activate users")
+            flash("Failed to activate users. Please check the logs.", "error")
 
     @action(
         "deactivate",
@@ -121,9 +122,10 @@ class UserView(ModelView):
                 if len(users) == 1
                 else f"{len(users)} users were successfully deactivated."
             )
-        except Exception as e:  # pragma: no cover
+        except Exception:  # pragma: no cover
             self.session.rollback()
-            flash(f"Failed to deactivate users. {e}", "error")
+            current_app.logger.exception("Failed to deactivate users")
+            flash("Failed to deactivate users. Please check the logs.", "error")
 
 
 class ArchitectureView(ModelView):
@@ -181,8 +183,13 @@ class ServiceView(ModelView):
     can_delete = False
 
 
+ALLOWED_SCREENSHOT_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp"}
+
+
 def screenshot_namegen(obj, file_data):
-    ext = os.path.splitext(file_data.filename)[1]
+    ext = os.path.splitext(file_data.filename)[1].lower()
+    if ext not in ALLOWED_SCREENSHOT_EXTENSIONS:
+        raise ValueError(f"Invalid screenshot file extension: {ext!r}")
     i = 1
     while os.path.exists(
         os.path.join(
@@ -214,9 +221,9 @@ class ScreenshotView(ModelView):
     }
 
     def _display(view, context, model, name):
+        safe_url = Markup.escape(url_for("nas.data", path=model.path))
         return Markup(
-            f'<img src="{url_for("nas.data", path=model.path)}" '
-            'alt="screenshot" height="100" width="100">'
+            f'<img src="{safe_url}" alt="screenshot" height="100" width="100">'
         )
 
     column_formatters = {"path": _display}
@@ -368,8 +375,11 @@ def _apply_info_from_spk(session, build, spk, md5_hash):
                 icon.path = icon_path
             icon.save(icon_stream)
 
+    arch_value = info.get("arch")
+    if not arch_value:
+        raise ValueError("Missing 'arch' field in INFO")
     architectures = []
-    for info_arch in info["arch"].split():
+    for info_arch in arch_value.split():
         architecture = Architecture.find(info_arch, syno=True)
         if architecture is None:
             raise ValueError(f"Unknown architecture: {info_arch}")
@@ -562,10 +572,9 @@ class VersionView(ModelView):
         text = getattr(model, name)
         if not text:
             return text
-        escaped = Markup.escape(text)
         if len(text) > 250:
-            return Markup(f"{escaped[:250]}...")
-        return escaped
+            return Markup(f"{Markup.escape(text[:250])}...")
+        return Markup.escape(text)
 
     # View
     column_list = (
@@ -666,9 +675,10 @@ class VersionView(ModelView):
                     f"{len(versions)} versions."
                 )
             )
-        except Exception as e:  # pragma: no cover
+        except Exception:  # pragma: no cover
             self.session.rollback()
-            flash(f"Failed to activate versions' builds. {e}", "error")
+            current_app.logger.exception("Failed to activate versions' builds")
+            flash("Failed to activate versions' builds. Please check the logs.", "error")
 
     @action(
         "deactivate",
@@ -690,9 +700,10 @@ class VersionView(ModelView):
                     f"{len(versions)} versions."
                 )
             )
-        except Exception as e:  # pragma: no cover
+        except Exception:  # pragma: no cover
             self.session.rollback()
-            flash(f"Failed to deactivate versions' builds. {e}", "error")
+            current_app.logger.exception("Failed to deactivate versions' builds")
+            flash("Failed to deactivate versions' builds. Please check the logs.", "error")
 
     @action("sign", "Sign", "Are you sure you want to sign selected builds?")
     def action_sign(self, ids):
@@ -720,6 +731,7 @@ class VersionView(ModelView):
                             self.session.commit()
                             success.append(filename)
                         except Exception:
+                            current_app.logger.exception("Failed to sign build %s", filename)
                             self.session.rollback()
                             failed.append(filename)
             _flash_action_results(
@@ -728,8 +740,9 @@ class VersionView(ModelView):
                 skipped=already_signed,
                 item_label="build",
             )
-        except Exception as e:  # pragma: no cover
-            flash(f"Failed to sign builds. {e}", "error")
+        except Exception:  # pragma: no cover
+            current_app.logger.exception("Failed to sign builds")
+            flash("Failed to sign builds. Please check the logs.", "error")
 
     @action("unsign", "Unsign", "Are you sure you want to unsign selected builds?")
     def action_unsign(self, ids):
@@ -754,6 +767,7 @@ class VersionView(ModelView):
                             self.session.commit()
                             success.append(filename)
                         except Exception:
+                            current_app.logger.exception("Failed to unsign build %s", filename)
                             self.session.rollback()
                             failed.append(filename)
             _flash_action_results(
@@ -762,8 +776,9 @@ class VersionView(ModelView):
                 skipped=not_signed,
                 item_label="build",
             )
-        except Exception as e:  # pragma: no cover
-            flash(f"Failed to unsign builds. {e}", "error")
+        except Exception:  # pragma: no cover
+            current_app.logger.exception("Failed to unsign builds")
+            flash("Failed to unsign builds. Please check the logs.", "error")
 
     @action(
         "resync_info",
@@ -828,6 +843,10 @@ class VersionView(ModelView):
         if action == "resync_info" and not self.can_resync_info:
             abort(403)
         if action == "resync_file" and not self.can_resync_file:
+            abort(403)
+        if action == "sign" and not self.can_sign:
+            abort(403)
+        if action == "unsign" and not self.can_unsign:
             abort(403)
         return super(VersionView, self).handle_action(return_view)
 
@@ -966,9 +985,10 @@ class BuildView(ModelView):
                 if len(builds) == 1
                 else f"{len(builds)} builds were successfully activated."
             )
-        except Exception as e:  # pragma: no cover
+        except Exception:  # pragma: no cover
             self.session.rollback()
-            flash(f"Failed to activate builds. {e}", "error")
+            current_app.logger.exception("Failed to activate builds")
+            flash("Failed to activate builds. Please check the logs.", "error")
 
     @action(
         "deactivate",
@@ -986,9 +1006,10 @@ class BuildView(ModelView):
                 if len(builds) == 1
                 else f"{len(builds)} builds were successfully deactivated."
             )
-        except Exception as e:  # pragma: no cover
+        except Exception:  # pragma: no cover
             self.session.rollback()
-            flash(f"Failed to deactivate builds. {e}", "error")
+            current_app.logger.exception("Failed to deactivate builds")
+            flash("Failed to deactivate builds. Please check the logs.", "error")
 
     @action("sign", "Sign", "Are you sure you want to sign selected builds?")
     def action_sign(self, ids):
@@ -1015,6 +1036,9 @@ class BuildView(ModelView):
                         self.session.commit()
                         success.append(filename)
                     except Exception:
+                        current_app.logger.exception(
+                            "Failed to sign build %s", filename
+                        )
                         self.session.rollback()
                         failed.append(filename)
             _flash_action_results(
@@ -1023,8 +1047,9 @@ class BuildView(ModelView):
                 skipped=already_signed,
                 item_label="build",
             )
-        except Exception as e:  # pragma: no cover
-            flash(f"Failed to sign builds. {e}", "error")
+        except Exception:  # pragma: no cover
+            current_app.logger.exception("Failed to sign builds")
+            flash("Failed to sign builds. Please check the logs.", "error")
 
     @action("unsign", "Unsign", "Are you sure you want to unsign selected builds?")
     def action_unsign(self, ids):
@@ -1048,6 +1073,7 @@ class BuildView(ModelView):
                         self.session.commit()
                         success.append(filename)
                     except Exception:
+                        current_app.logger.exception("Failed to unsign build %s", filename)
                         self.session.rollback()
                         failed.append(filename)
             _flash_action_results(
@@ -1056,8 +1082,9 @@ class BuildView(ModelView):
                 skipped=not_signed,
                 item_label="build",
             )
-        except Exception as e:  # pragma: no cover
-            flash(f"Failed to unsign builds. {e}", "error")
+        except Exception:  # pragma: no cover
+            current_app.logger.exception("Failed to unsign builds")
+            flash("Failed to unsign builds. Please check the logs.", "error")
 
     @action(
         "resync_info",
@@ -1134,6 +1161,10 @@ class BuildView(ModelView):
         if action == "resync_info" and not self.can_resync_info:
             abort(403)
         if action == "resync_file" and not self.can_resync_file:
+            abort(403)
+        if action == "sign" and not self.can_sign:
+            abort(403)
+        if action == "unsign" and not self.can_unsign:
             abort(403)
         return super(BuildView, self).handle_action(return_view)
 

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -678,7 +678,9 @@ class VersionView(ModelView):
         except Exception:  # pragma: no cover
             self.session.rollback()
             current_app.logger.exception("Failed to activate versions' builds")
-            flash("Failed to activate versions' builds. Please check the logs.", "error")
+            flash(
+                "Failed to activate versions' builds. Please check the logs.", "error"
+            )
 
     @action(
         "deactivate",
@@ -703,7 +705,9 @@ class VersionView(ModelView):
         except Exception:  # pragma: no cover
             self.session.rollback()
             current_app.logger.exception("Failed to deactivate versions' builds")
-            flash("Failed to deactivate versions' builds. Please check the logs.", "error")
+            flash(
+                "Failed to deactivate versions' builds. Please check the logs.", "error"
+            )
 
     @action("sign", "Sign", "Are you sure you want to sign selected builds?")
     def action_sign(self, ids):
@@ -731,7 +735,9 @@ class VersionView(ModelView):
                             self.session.commit()
                             success.append(filename)
                         except Exception:
-                            current_app.logger.exception("Failed to sign build %s", filename)
+                            current_app.logger.exception(
+                                "Failed to sign build %s", filename
+                            )
                             self.session.rollback()
                             failed.append(filename)
             _flash_action_results(
@@ -767,7 +773,9 @@ class VersionView(ModelView):
                             self.session.commit()
                             success.append(filename)
                         except Exception:
-                            current_app.logger.exception("Failed to unsign build %s", filename)
+                            current_app.logger.exception(
+                                "Failed to unsign build %s", filename
+                            )
                             self.session.rollback()
                             failed.append(filename)
             _flash_action_results(
@@ -1073,7 +1081,9 @@ class BuildView(ModelView):
                         self.session.commit()
                         success.append(filename)
                     except Exception:
-                        current_app.logger.exception("Failed to unsign build %s", filename)
+                        current_app.logger.exception(
+                            "Failed to unsign build %s", filename
+                        )
                         self.session.rollback()
                         failed.append(filename)
             _flash_action_results(

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -601,9 +601,7 @@ class VersionView(ModelView):
             f"{m.total_size / 1024 / 1024:.1f} MB" if m.total_size else None
         ),
     }
-    column_formatters_detail = {
-        'license': _truncate_formatter
-    }
+    column_formatters_detail = {"license": _truncate_formatter}
     column_default_sort = (Version.insert_date, True)
 
     # Custom queries

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -263,9 +263,7 @@ class Packages(Resource):
             )
             candidate_min_build = firmware.build
             candidate_max_build = (
-                firmware_max.build
-                if firmware_max is not None
-                else candidate_min_build
+                firmware_max.build if firmware_max is not None else candidate_min_build
             )
             if (
                 candidate_min_build > existing_max_build

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -177,7 +177,9 @@ class Packages(Resource):
         version = {v.version: v for v in package.versions}.get(
             int(match.group("version"))
         )
-        if version is not None and version.upstream_version != match.group("upstream_version"):
+        if version is not None and version.upstream_version != match.group(
+            "upstream_version"
+        ):
             abort(
                 422,
                 message=(

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -174,10 +174,17 @@ class Packages(Resource):
         match = version_re.match(spk.info["version"])
         if not match:
             abort(422, message="Invalid version")
-        # TODO: check discrepencies with what's in the database
         version = {v.version: v for v in package.versions}.get(
             int(match.group("version"))
         )
+        if version is not None and version.upstream_version != match.group("upstream_version"):
+            abort(
+                422,
+                message=(
+                    f"Upstream version mismatch: expected {version.upstream_version}, "
+                    f"got {match.group('upstream_version')}"
+                ),
+            )
         if version is None:
             create_version = True
             version_startable = True  # default per Synology docs

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -180,11 +180,9 @@ class Packages(Resource):
         )
         if version is None:
             create_version = True
-            version_startable = None
+            version_startable = True  # default per Synology docs
             if spk.info.get("startable") is False or spk.info.get("ctl_stop") is False:
                 version_startable = False
-            elif spk.info.get("startable") is True or spk.info.get("ctl_stop") is True:
-                version_startable = True
             version = Version(
                 package=package,
                 upstream_version=match.group("upstream_version"),
@@ -316,6 +314,7 @@ class Packages(Resource):
             build.save(spk.stream)
             # generate md5 hash
             build.md5 = build.calculate_md5()
+            build.size = os.path.getsize(os.path.join(data_path, build.path))
         except Exception as e:  # pragma: no cover
             if create_package:
                 shutil.rmtree(os.path.join(data_path, package.name), ignore_errors=True)

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import io
+import logging
 import os
 import re
 import shutil
@@ -28,6 +29,8 @@ from ..models import (
     user_datastore,
 )
 from ..utils import SPK
+
+logger = logging.getLogger(__name__)
 
 api = Blueprint("api", __name__)
 
@@ -189,7 +192,7 @@ class Packages(Resource):
             )
         if version is None:
             create_version = True
-            version_startable = True  # default per Synology docs
+            version_startable = True
             if spk.info.get("startable") is False or spk.info.get("ctl_stop") is False:
                 version_startable = False
             version = Version(
@@ -244,37 +247,35 @@ class Packages(Resource):
                     size=size,
                 )
 
-        # Build
-        if version.id:
-            # check for conflicts
-            conflicts = set()
-            for existing_build in version.builds:
-                overlapping_architectures = set(existing_build.architectures) & set(
-                    architectures
-                )
-                if not overlapping_architectures:
-                    continue
-                existing_min_build = existing_build.firmware_min.build
-                existing_max_build = (
-                    existing_build.firmware_max.build
-                    if existing_build.firmware_max
-                    else existing_min_build
-                )
-                candidate_min_build = firmware.build
-                candidate_max_build = (
-                    firmware_max.build
-                    if firmware_max is not None
-                    else candidate_min_build
-                )
-                if (
-                    candidate_min_build > existing_max_build
-                    or candidate_max_build < existing_min_build
-                ):
-                    continue
-                conflicts |= overlapping_architectures
-            if conflicts:
-                conflict_codes = ", ".join(sorted(a.code for a in conflicts))
-                abort(409, message=f"Conflicting architectures: {conflict_codes}")
+        # Build — conflict check is a no-op for new versions but kept unconditional
+        conflicts = set()
+        for existing_build in version.builds:
+            overlapping_architectures = set(existing_build.architectures) & set(
+                architectures
+            )
+            if not overlapping_architectures:
+                continue
+            existing_min_build = existing_build.firmware_min.build
+            existing_max_build = (
+                existing_build.firmware_max.build
+                if existing_build.firmware_max
+                else existing_min_build
+            )
+            candidate_min_build = firmware.build
+            candidate_max_build = (
+                firmware_max.build
+                if firmware_max is not None
+                else candidate_min_build
+            )
+            if (
+                candidate_min_build > existing_max_build
+                or candidate_max_build < existing_min_build
+            ):
+                continue
+            conflicts |= overlapping_architectures
+        if conflicts:
+            conflict_codes = ", ".join(sorted(a.code for a in conflicts))
+            abort(409, message=f"Conflicting architectures: {conflict_codes}")
 
         build_filename = Build.generate_filename(
             package, version, firmware, architectures
@@ -321,10 +322,10 @@ class Packages(Resource):
                 for size, icon in build.version.icons.items():
                     icon.save(spk.icons[size])
             build.save(spk.stream)
-            # generate md5 hash
             build.md5 = build.calculate_md5()
             build.size = build.calculate_size()
         except Exception as e:  # pragma: no cover
+            logger.exception("Failed to save SPK files for package %s", package.name)
             if create_package:
                 shutil.rmtree(os.path.join(data_path, package.name), ignore_errors=True)
             elif create_version:
@@ -343,7 +344,6 @@ class Packages(Resource):
         db.session.add(build)
         db.session.commit()
 
-        # success
         return (
             {
                 "package": package.name,

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -314,7 +314,7 @@ class Packages(Resource):
             build.save(spk.stream)
             # generate md5 hash
             build.md5 = build.calculate_md5()
-            build.size = os.path.getsize(os.path.join(data_path, build.path))
+            build.size = build.calculate_size()
         except Exception as e:  # pragma: no cover
             if create_package:
                 shutil.rmtree(os.path.join(data_path, package.name), ignore_errors=True)

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -25,15 +25,6 @@ class GenerateApiKeyForm(FlaskForm):
     api_key = StringField("API Key")
     submit = SubmitField("Generate API Key")
 
-    def validate(self, extra_validators=None):
-        if not super(GenerateApiKeyForm, self).validate():  # pragma: no cover
-            return False
-
-        if not current_user.has_role("developer"):
-            return False
-
-        return True
-
 
 def generate_api_key():
     """
@@ -48,10 +39,13 @@ def generate_api_key():
 @frontend.route("/profile", methods=["GET", "POST"])
 @login_required
 def profile():
+    if not current_user.has_role("developer"):
+        return render_template(
+            "frontend/profile.html",
+            change_password_form=ChangePasswordForm(),
+        )
     form = GenerateApiKeyForm()
     if form.validate_on_submit():
-        if not current_user.has_role("developer"):
-            abort(403)
         current_user.api_key = generate_api_key()
         db.session.commit()
         return redirect(url_for("frontend.profile"), code=303)

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -98,8 +98,7 @@ def packages():
 @frontend.route("/package/<name>")
 def package(name):
     package = (
-        Package.query
-        .filter_by(name=name)
+        Package.query.filter_by(name=name)
         .options(
             db.joinedload(Package.versions).joinedload(Version.icons),
             db.joinedload(Package.versions).joinedload(Version.displaynames),

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-import hashlib
-import os
+import secrets
 
 from flask import Blueprint, abort, redirect, render_template, url_for
 from flask_security import RegisterFormV2, current_user, login_required
@@ -38,12 +37,12 @@ class GenerateApiKeyForm(FlaskForm):
 
 def generate_api_key():
     """
-    Generate a random API key based on `os.urandom`
+    Generate a random API key based on `secrets.token_hex`
 
     :return: the generated API key
     :rtype: str
     """
-    return hashlib.sha256(os.urandom(32)).hexdigest()
+    return secrets.token_hex(32)
 
 
 @frontend.route("/profile", methods=["GET", "POST"])
@@ -51,6 +50,8 @@ def generate_api_key():
 def profile():
     form = GenerateApiKeyForm()
     if form.validate_on_submit():
+        if not current_user.has_role("developer"):
+            abort(403)
         current_user.api_key = generate_api_key()
         db.session.commit()
         return redirect(url_for("frontend.profile"), code=303)
@@ -96,7 +97,16 @@ def packages():
 
 @frontend.route("/package/<name>")
 def package(name):
-    package = Package.query.filter_by(name=name).first()
+    package = (
+        Package.query
+        .filter_by(name=name)
+        .options(
+            db.joinedload(Package.versions).joinedload(Version.icons),
+            db.joinedload(Package.versions).joinedload(Version.displaynames),
+            db.joinedload(Package.versions).joinedload(Version.descriptions),
+        )
+        .first()
+    )
     if package is None or not package.versions:
         abort(404)
     return render_template("frontend/package.html", package=package)

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -31,16 +31,12 @@ nas = Blueprint("nas", __name__)
 
 @cache.memoize(timeout=600)
 def is_valid_arch(arch):
-    if Architecture.find(arch):
-        return True
-    return False
+    return Architecture.find(arch) is not None
 
 
 @cache.memoize(timeout=600)
 def is_valid_language(language):
-    if Language.find(language):
-        return True
-    return False
+    return Language.find(language) is not None
 
 
 @cache.memoize(timeout=600)
@@ -228,7 +224,7 @@ def build_package_entry(b, language, arch, build):
     if b.size:
         entry["size"] = b.size
     if b.version.startable is not None:
-        entry["startable"] = "yes" if b.version.startable is not False else "no"
+        entry["startable"] = "yes" if b.version.startable else "no"
 
     return entry
 

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -152,19 +152,20 @@ def get_catalog(arch, build, major, language, beta):
 
     # DSM 5.1
     if build >= 5004:
-        keyrings = []
-        if current_app.config["GNUPG_PATH"] is not None:  # pragma: no cover
-            gpg = gnupg.GPG(gnupghome=current_app.config["GNUPG_PATH"])
-            keyrings.append(
-                gpg.export_keys(current_app.config["GNUPG_FINGERPRINT"]).strip()
-            )
+        result = {"packages": packages}
+        # DSM 6 only
+        if build < 40000:
+            keyrings = []
+            if current_app.config["GNUPG_PATH"] is not None:  # pragma: no cover
+                gpg = gnupg.GPG(gnupghome=current_app.config["GNUPG_PATH"])
+                keyrings.append(
+                    gpg.export_keys(current_app.config["GNUPG_FINGERPRINT"]).strip()
+                )
+            result["keyrings"] = keyrings
+    else:
+        result = packages
 
-        return {
-            "packages": packages,
-            "keyrings": keyrings,
-        }
-
-    return packages
+    return result
 
 
 def build_package_entry(b, language, arch, build):
@@ -201,11 +202,14 @@ def build_package_entry(b, language, arch, build):
         "recent_download_count": b.version.package.recent_download_count,
     }
 
-    if b.version.package.screenshots:
-        entry["snapshot"] = [
+    entry["snapshot"] = (
+        [
             url_for(".data", path=screenshot.path, _external=True)
             for screenshot in b.version.package.screenshots
         ]
+        if b.version.package.screenshots
+        else []
+    )
     if b.version.report_url:
         entry["report_url"] = b.version.report_url
         entry["beta"] = True
@@ -219,20 +223,12 @@ def build_package_entry(b, language, arch, build):
         entry["maintainer"] = b.version.maintainer
     if b.version.maintainer_url:
         entry["maintainer_url"] = b.version.maintainer_url
-    if b.version.service_dependencies:
-        entry["depsers"] = " ".join(
-            [service.code for service in b.version.service_dependencies]
-        )
     if b.md5:
         entry["md5"] = b.md5
-    if b.buildmanifest and b.buildmanifest.conf_dependencies:
-        entry["conf_deppkgs"] = b.buildmanifest.conf_dependencies
-    if b.buildmanifest and b.buildmanifest.conf_conflicts:
-        entry["conf_conxpkgs"] = b.buildmanifest.conf_conflicts
-    if b.buildmanifest and b.buildmanifest.conf_privilege:
-        entry["conf_privilege"] = b.buildmanifest.conf_privilege
-    if b.buildmanifest and b.buildmanifest.conf_resource:
-        entry["conf_resource"] = b.buildmanifest.conf_resource
+    if b.size:
+        entry["size"] = b.size
+    if b.version.startable is not None:
+        entry["startable"] = "yes" if b.version.startable is not False else "no"
 
     return entry
 


### PR DESCRIPTION
## Summary

Replaces `extract_size` with `size` on `Build`, fixes catalog response format for DSM 5/6/7, removes legacy conf/service fields from the catalog, and adds a `_resync_build_file` helper alongside several correctness and security fixes across the codebase.

## Changes

### Models (`models.py`)
- Replaced `Build.extract_size` column with `size` (backed by a new migration).
- Added `Build.calculate_size()` method alongside the existing `calculate_md5()`.
- `calculate_md5()` no longer short-circuits when `md5` is already set — it always reads from disk.
- Added dialect-aware `_days_ago` SQL expression (SQLite + PostgreSQL) to support time-windowed download counts.
- Simplified `Version.any_builds_active` SQL expression to use `~exists()` instead of a count comparison.
- Moved `beta` hybrid expression to follow `beta` property definition; removed redundant `version_string` property duplicate.

### NAS / Catalog (`nas.py`)
- Fixed catalog response format: DSM < 5004 now returns a bare list; DSM 5004–39999 returns `{packages, keyrings}`; DSM 7+ returns `{packages}` with no keyrings.
- Removed `depsers`, `conf_deppkgs`, `conf_conxpkgs`, `conf_privilege`, and `conf_resource` fields from catalog entries.
- Added `size` and `startable` fields to catalog entries.
- `snapshot` is now always present in catalog entries (empty list when no screenshots).
- Simplified `is_valid_arch` / `is_valid_language` helpers to use `is not None`.

### API (`api.py`)
- Added upstream version mismatch check (returns 422) when uploading a new build for an existing version — resolves a prior TODO.
- `version_startable` now defaults to `True` instead of `None`; removed redundant `startable=True` branch.
- Build conflict check is now unconditional (previously skipped for new versions).
- `build.size` is now calculated and stored after saving the SPK file.
- Added structured logging (`logger.exception`) on save failure.

### Admin (`admin.py`)
- Added `_bool_formatter` for icon-based boolean display in admin views.
- Added `_flash_action_results` helper for consistent flash messaging across bulk actions.
- Added `_resync_build_file` helper to recalculate `md5` and `size` from disk.
- Screenshot upload now validates file extension (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`) and normalises to lowercase.
- Screenshot `<img>` src is now XSS-safe via `Markup.escape`.
- `startable` defaults to `True` (per Synology docs) instead of `None`; removed redundant `startable=True` branch.
- `arch` field is validated as non-empty before splitting.
- Error handlers in bulk activate/deactivate now log via `current_app.logger.exception` and show a generic message rather than leaking exception details.
- Package list columns extended to include `download_count` and `recent_download_count`.
- Added new `admin/index.html` template.

### Frontend (`frontend.py`)
- Replaced `hashlib.sha256(os.urandom(32)).hexdigest()` with `secrets.token_hex(32)` for API key generation (produces a 64-char hex string).
- Non-developer users are now short-circuited early in the `profile` view before the form is processed.
- Removed redundant role check from `GenerateApiKeyForm.validate()`.
- `package` view now eager-loads `icons`, `displaynames`, and `descriptions` to avoid N+1 queries.

### Fixtures (`utils.py`)
- Added DSM 6.2 (build 23739) and DSM 7.1 (build 42661) firmware seed entries.

## Tests

### `test_api.py`
- Updated `assertBuildInserted` to check `size` (non-null, positive) instead of `extract_size`; `startable` assertion now accounts for the new default of `True` when the factory produces `None`.
- Fixed flaky firmware fixture: `firmware_min` pinned to lowest seeded build, `newer_firmware` always resolves to highest, with an explicit ordering assertion.
- **New:** upstream version mismatch returns 422; `firmware_max` happy path and all three error paths (invalid format, unknown build, max < min); overlapping vs. non-overlapping firmware range conflict checks; unknown `install_dep_services` returns 422; maintainer-on-wrong-package returns 403; 201 response body shape verified.

### `test_nas.py`
- `assertCatalogEntry` updated: dropped fields (`depsers`, `conf_deppkgs`, `conf_conxpkgs`, `conf_privilege`, `conf_resource`) removed; `size`, `startable`, `download_count`, and `recent_download_count` added; `snapshot` always asserted present.
- All catalog tests now handle the polymorphic response shape (bare list for DSM < 5004, dict for DSM 5004+). DSM 5004 fixtures migrated to the seeded DSM 6.2 firmware (build 23739); a pre-existing arch test that wrongly expected 0 results fixed to expect 1.
- Several test names updated to describe intent rather than implementation detail.
- **New:** DSM 6 response includes `keyrings`; DSM 7 response omits `keyrings`; beta packages excluded on DSM 7 even with `package_update_channel=beta`; explicit `major` parameter overrides firmware table; invalid `major` returns 422; beta entry fields (`report_url`, `beta`) verified; download request above `firmware_max` returns 400.

### `test_admin.py`
- `test_action_resync_refreshes_metadata` split into separate version-metadata and build-metadata cases; build-metadata case pins firmware to lowest/highest seeded values and adds pre-resync corruption assertions to confirm the resync is actually doing work.
- Flash message assertions updated to match new wording; renamed tests align with updated action labels.
- **New:** `resync_file` action (version + build views) — nulling `md5`/`size` and resyncing restores both, verified non-null and positive; `resync_info` and `resync_file` both return 403 for `package_admin` without `admin` role; single and multi-select activate/deactivate with correct flash messages; developer sees only their own package's builds; `ScreenshotDeleteTestCase` verifies file is removed from disk on delete.

### `test_frontend.py`
- API key form lookup now searches by field name rather than assuming `forms[0]`.
- **New:** existing key pre-populated on GET; generated key matches `^[0-9a-f]{64}$`; empty packages page returns 200; package with no versions returns 404; username too short rejected at registration; successful registration persists user correctly.