### PR TITLE
Frontend fixes and build view improvements

### DIFF
--- a/spkrepo/static/css/spkrepo.css
+++ b/spkrepo/static/css/spkrepo.css
@@ -37,10 +37,12 @@
 }
 .package-description {
     height: 100px;
+    width: 100%;
     overflow: hidden;
     display: -webkit-box;
     -webkit-line-clamp: 4;
     -webkit-box-orient: vertical;
+    word-break: break-word;
 }
 .package-screenshots {
     text-align: center;

--- a/spkrepo/templates/frontend/packages.html
+++ b/spkrepo/templates/frontend/packages.html
@@ -7,7 +7,7 @@
     {% for version in version_row %}
     <div class="col-md-4">
       <div class="d-flex">
-        <div class="flex-shrink-0 mr-3">
+        <div class="flex-shrink-0 mr-3" style="width: 72px;">
           <a href="{{ url_for('frontend.package', name=version.package.name) }}">
             <img src="{{ url_for('nas.data', path=version.icons['72'].path) }}" alt="Icon">
           </a>

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from wtforms import PasswordField
 from wtforms.validators import Regexp
 
-from ..ext import db
+from ..ext import cache, db
 from ..models import (
     Architecture,
     Build,
@@ -641,6 +641,12 @@ class PackageView(ModelView):
         if os.path.exists(package_path):
             shutil.rmtree(package_path)
 
+    def after_model_change(self, form, model, is_created):
+        cache.delete("packages_versions")
+
+    def after_model_delete(self, model):
+        cache.delete("packages_versions")
+
     column_list = (
         "name",
         "author",
@@ -801,6 +807,7 @@ class VersionView(SignResyncMixin, ModelView):
                 for build in version.builds:
                     build.active = True
             db.session.commit()
+            cache.delete("packages_versions")
             flash(
                 "Builds on version were successfully activated."
                 if len(versions) == 1
@@ -828,6 +835,7 @@ class VersionView(SignResyncMixin, ModelView):
                 for build in version.builds:
                     build.active = False
             db.session.commit()
+            cache.delete("packages_versions")
             flash(
                 "Builds on version were successfully deactivated."
                 if len(versions) == 1
@@ -949,6 +957,12 @@ class BuildView(SignResyncMixin, ModelView):
         if os.path.exists(build_path):
             os.remove(build_path)
 
+    def after_model_change(self, form, model, is_created):
+        cache.delete("packages_versions")
+
+    def after_model_delete(self, model):
+        cache.delete("packages_versions")
+
     @action(
         "activate", "Activate", "Are you sure you want to activate selected builds?"
     )
@@ -958,6 +972,7 @@ class BuildView(SignResyncMixin, ModelView):
             for build in builds:
                 build.active = True
             db.session.commit()
+            cache.delete("packages_versions")
             flash(
                 "Build was successfully activated."
                 if len(builds) == 1
@@ -979,6 +994,7 @@ class BuildView(SignResyncMixin, ModelView):
             for build in builds:
                 build.active = False
             db.session.commit()
+            cache.delete("packages_versions")
             flash(
                 "Build was successfully deactivated."
                 if len(builds) == 1

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -887,8 +887,8 @@ class BuildView(SignResyncMixin, ModelView):
         "version.version",
         "architectures",
         "firmware_min",
-        "firmware_max",
-        "size",
+        "publisher",
+        "insert_date",
         "active",
     )
     column_labels = {
@@ -909,17 +909,16 @@ class BuildView(SignResyncMixin, ModelView):
         "version.version",
         "architectures.code",
         "firmware_min.version",
-        "firmware_max.version",
-        "size",
+        "publisher.username",
         "active",
     )
     column_sortable_list = (
         ("version.package", "version.package.name"),
         ("version.version", "version.version"),
         ("firmware_min", "firmware_min.build"),
-        ("firmware_max", "firmware_max.build"),
+        ("publisher", "publisher.username"),
+        ("insert_date", "insert_date"),
         ("active", "active"),
-        ("size", "size"),
     )
     column_formatters = {
         "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -53,36 +53,36 @@ def profile():
 
 
 @frontend.route("/packages")
-@cache.cached(timeout=300)
 def packages():
-    # Show only packages with at least one version, but ignore whether builds
-    # are active.
-    latest_version = (
-        db.session.query(
-            Version.package_id, db.func.max(Version.version).label("latest_version")
+    versions = cache.get("packages_versions")
+    if versions is None:
+        latest_version = (
+            db.session.query(
+                Version.package_id, db.func.max(Version.version).label("latest_version")
+            )
+            .join(Build)
+            .group_by(Version.package_id)
+            .subquery()
         )
-        .join(Build)
-        .group_by(Version.package_id)
-        .subquery()
-    )
-    versions = (
-        Version.query.join(Version.package)
-        .options(
-            db.joinedload(Version.package),
-            db.joinedload(Version.icons),
-            db.joinedload(Version.displaynames).joinedload(DisplayName.language),
-            db.joinedload(Version.descriptions).joinedload(Description.language),
+        versions = (
+            Version.query.join(Version.package)
+            .options(
+                db.joinedload(Version.package),
+                db.joinedload(Version.icons),
+                db.joinedload(Version.displaynames).joinedload(DisplayName.language),
+                db.joinedload(Version.descriptions).joinedload(Description.language),
+            )
+            .join(
+                latest_version,
+                db.and_(
+                    Version.package_id == latest_version.c.package_id,
+                    Version.version == latest_version.c.latest_version,
+                ),
+            )
+            .order_by(Package.name)
+            .all()
         )
-        .join(
-            latest_version,
-            db.and_(
-                Version.package_id == latest_version.c.package_id,
-                Version.version == latest_version.c.latest_version,
-            ),
-        )
-        .order_by(Package.name)
-        .all()
-    )
+        cache.set("packages_versions", versions, timeout=300)
     return render_template("frontend/packages.html", versions=versions)
 
 


### PR DESCRIPTION
## Description

This PR addresses several user-facing issues discovered after the Bootstrap 4 upgrade and initial deployment.

**Bug fixes**
- Prevent package description text from overflowing its column in Chrome and Safari by adding `word-break: break-word` to the CSS
- Fix package icons on the packages page having inconsistent widths causing misaligned text by constraining the icon container to a fixed 72px width
- Fix the navbar disappearing for logged-in users on the packages page by caching the database query result rather than the full rendered HTML response, with cache invalidation on package and build changes

**Admin improvements**
- Restore `publisher` and `insert_date` columns to the Build view, update filters and sortable columns accordingly, and remove `firmware_max` and `size` columns to make room