### PR TITLE
Admin: resync permissions, unsign guard, and total_size sorting

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -639,11 +639,20 @@ class Version(db.Model):
             )
         return result
 
-    @property
+    @hybrid_property
     def total_size(self):
         # Returns None if no builds have a known size, rather than 0
         total = sum(b.size for b in self.builds if b.size is not None)
         return total or None
+
+    @total_size.expression
+    def total_size(cls):
+        return (
+            db.select(db.func.sum(Build.size))
+            .where(Build.version_id == cls.id)
+            .correlate(cls)
+            .scalar_subquery()
+        )
 
 
 class Package(db.Model):

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -210,8 +210,14 @@ class VersionTestCase(BaseTestCase):
         self.assertEqual(len(Version.query.all()), 0)
         self.assertTrue(not os.path.exists(version_path))
 
-    def test_action_resync_info_requires_admin(self):
+    def test_action_resync_info_visible_to_package_admin(self):
         with self.logged_user("package_admin"):
+            response = self.client.get(url_for("version.index_view"))
+            self.assert200(response)
+            self.assertIn("Resync Info", response.data.decode())
+
+    def test_action_resync_info_requires_admin_or_package_admin(self):
+        with self.logged_user("developer"):
             response = self.client.get(url_for("version.index_view"))
             self.assert200(response)
             self.assertNotIn("Resync Info", response.data.decode())
@@ -332,8 +338,14 @@ class VersionTestCase(BaseTestCase):
         )
         self.assertEqual(refreshed_build.md5, refreshed_build.calculate_md5())
 
-    def test_action_resync_file_requires_admin(self):
+    def test_action_resync_file_visible_to_package_admin(self):
         with self.logged_user("package_admin"):
+            response = self.client.get(url_for("version.index_view"))
+            self.assert200(response)
+            self.assertIn("Resync File", response.data.decode())
+
+    def test_action_resync_file_requires_admin_or_package_admin(self):
+        with self.logged_user("developer"):
             response = self.client.get(url_for("version.index_view"))
             self.assert200(response)
             self.assertNotIn("Resync File", response.data.decode())
@@ -440,20 +452,48 @@ class VersionTestCase(BaseTestCase):
         self.assertFalse(db.session.get(Build, build1.id).active)
         self.assertFalse(db.session.get(Build, build2.id).active)
 
-    def test_action_resync_info_blocked_for_non_admin(self):
+    def test_action_resync_info_allowed_for_package_admin(self):
         build = BuildFactory()
         db.session.commit()
         with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build.version.id]),
+            )
+        self.assert200(response)
+        self.assertIn("refreshed", response.data.decode())
+
+    def test_action_resync_info_blocked_for_developer(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("developer") as user:
+            build.version.package.maintainers.append(user)
+            db.session.commit()
             response = self.client.post(
                 url_for("version.action_view"),
                 data=dict(action="resync_info", rowid=[build.version.id]),
             )
         self.assert403(response)
 
-    def test_action_resync_file_blocked_for_non_admin(self):
+    def test_action_resync_file_allowed_for_package_admin(self):
         build = BuildFactory()
         db.session.commit()
         with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_file", rowid=[build.version.id]),
+            )
+        self.assert200(response)
+        self.assertIn("refreshed", response.data.decode())
+
+    def test_action_resync_file_blocked_for_developer(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("developer") as user:
+            build.version.package.maintainers.append(user)
+            db.session.commit()
             response = self.client.post(
                 url_for("version.action_view"),
                 data=dict(action="resync_file", rowid=[build.version.id]),
@@ -549,8 +589,14 @@ class BuildTestCase(BaseTestCase):
             self.assertFalse(build1.active)
             self.assertFalse(build2.active)
 
-    def test_action_resync_info_requires_admin(self):
+    def test_action_resync_info_visible_to_package_admin(self):
         with self.logged_user("package_admin"):
+            response = self.client.get(url_for("build.index_view"))
+            self.assert200(response)
+            self.assertIn("Resync Info", response.data.decode())
+
+    def test_action_resync_info_requires_admin_or_package_admin(self):
+        with self.logged_user("developer"):
             response = self.client.get(url_for("build.index_view"))
             self.assert200(response)
             self.assertNotIn("Resync Info", response.data.decode())
@@ -603,8 +649,14 @@ class BuildTestCase(BaseTestCase):
             original_architectures,
         )
 
-    def test_action_resync_file_requires_admin(self):
+    def test_action_resync_file_visible_to_package_admin(self):
         with self.logged_user("package_admin"):
+            response = self.client.get(url_for("build.index_view"))
+            self.assert200(response)
+            self.assertIn("Resync File", response.data.decode())
+
+    def test_action_resync_file_requires_admin_or_package_admin(self):
+        with self.logged_user("developer"):
             response = self.client.get(url_for("build.index_view"))
             self.assert200(response)
             self.assertNotIn("Resync File", response.data.decode())
@@ -632,23 +684,85 @@ class BuildTestCase(BaseTestCase):
         self.assertIsNotNone(refreshed_build.size)
         self.assertGreater(refreshed_build.size, 0)
 
-    def test_action_resync_info_blocked_for_non_admin(self):
+    def test_action_resync_info_allowed_for_package_admin(self):
         build = BuildFactory()
         db.session.commit()
         with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build.id]),
+            )
+        self.assert200(response)
+        self.assertIn("refreshed", response.data.decode())
+
+    def test_action_resync_info_blocked_for_developer(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("developer") as user:
+            build.version.package.maintainers.append(user)
+            db.session.commit()
             response = self.client.post(
                 url_for("build.action_view"),
                 data=dict(action="resync_info", rowid=[build.id]),
             )
         self.assert403(response)
 
-    def test_action_resync_file_blocked_for_non_admin(self):
+    def test_action_resync_file_allowed_for_package_admin(self):
         build = BuildFactory()
         db.session.commit()
         with self.logged_user("package_admin"):
             response = self.client.post(
                 url_for("build.action_view"),
+                follow_redirects=True,
                 data=dict(action="resync_file", rowid=[build.id]),
+            )
+        self.assert200(response)
+        self.assertIn("refreshed", response.data.decode())
+
+    def test_action_resync_file_blocked_for_developer(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("developer") as user:
+            build.version.package.maintainers.append(user)
+            db.session.commit()
+            response = self.client.post(
+                url_for("build.action_view"),
+                data=dict(action="resync_file", rowid=[build.id]),
+            )
+        self.assert403(response)
+
+    def test_action_unsign_skips_active_build(self):
+        build = BuildFactory(active=True)
+        db.session.commit()
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                follow_redirects=True,
+                data=dict(action="unsign", rowid=[build.id]),
+            )
+        self.assert200(response)
+        self.assertIn("must be deactivated before unsigning", response.data.decode())
+        db.session.expire_all()
+        self.assertTrue(db.session.get(Build, build.id).active)
+
+    def test_action_sign_requires_admin(self):
+        build = BuildFactory()
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                data=dict(action="sign", rowid=[build.id]),
+            )
+        self.assert403(response)
+
+    def test_action_unsign_requires_admin(self):
+        build = BuildFactory(active=False)
+        db.session.commit()
+        with self.logged_user("package_admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                data=dict(action="unsign", rowid=[build.id]),
             )
         self.assert403(response)
 

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -282,11 +282,11 @@ class SignResyncMixin:
 
     @property
     def can_resync_info(self):
-        return current_user.has_role("admin")
+        return current_user.has_role("admin") or current_user.has_role("package_admin")
 
     @property
     def can_resync_file(self):
-        return current_user.has_role("admin")
+        return current_user.has_role("admin") or current_user.has_role("package_admin")
 
     # -- Permission guards --------------------------------------------------
 
@@ -361,8 +361,11 @@ class SignResyncMixin:
     @action("unsign", "Unsign", "Are you sure you want to unsign selected builds?")
     def action_unsign(self, ids):
         try:
-            not_signed, success, failed = [], [], []
+            not_signed, active_skipped, success, failed = [], [], [], []
             for label, build in self._iter_builds(ids):
+                if build.active:
+                    active_skipped.append(label)
+                    continue
                 with io.open(
                     os.path.join(current_app.config["DATA_PATH"], build.path), "rb+"
                 ) as f:
@@ -379,6 +382,18 @@ class SignResyncMixin:
                         current_app.logger.exception("Failed to unsign build %s", label)
                         db.session.rollback()
                         failed.append(label)
+            if active_skipped:
+                count = len(active_skipped)
+                flash(
+                    (
+                        f"Build {active_skipped[0]} must be deactivated before "
+                        f"unsigning."
+                        if count == 1
+                        else f"Skipped {count} active builds — deactivate before "
+                        f"unsigning: {', '.join(active_skipped)}"
+                    ),
+                    "warning",
+                )
             _flash_action_results(
                 success,
                 [(f, "") for f in failed],
@@ -449,6 +464,12 @@ class UserView(ModelView):
 
     form_columns = ("username", "roles", "active")
     form_overrides = {"password": PasswordField}
+
+    def after_model_change(self, form, model, is_created):
+        cache.delete("packages_versions")
+
+    def after_model_delete(self, model):
+        cache.delete("packages_versions")
 
     @action("activate", "Activate", "Are you sure you want to activate selected users?")
     def action_activate(self, ids):
@@ -581,9 +602,9 @@ class ScreenshotView(ModelView):
     column_filters = ("package.name",)
 
     def on_model_delete(self, model):
-        build_path = os.path.join(current_app.config["DATA_PATH"], model.path)
-        if os.path.exists(build_path):
-            os.remove(build_path)
+        screenshot_path = os.path.join(current_app.config["DATA_PATH"], model.path)
+        if os.path.exists(screenshot_path):
+            os.remove(screenshot_path)
 
     form_overrides = {"path": ImageUploadField}
     form_args = {
@@ -705,7 +726,8 @@ class VersionView(SignResyncMixin, ModelView):
         versions = get_query_for_ids(self.get_query(), self.model, ids).all()
         for version in versions:
             for build in version.builds:
-                yield os.path.basename(build.path), build
+                label = os.path.basename(build.path) if build.path else str(build.id)
+                yield label, build
 
     def on_model_delete(self, model):
         version_path = os.path.join(
@@ -757,6 +779,7 @@ class VersionView(SignResyncMixin, ModelView):
         ("insert_date", "insert_date"),
         ("all_builds_active", "all_builds_active"),
         ("startable", "startable"),
+        ("total_size", "total_size"),
     )
     column_formatters = {
         "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
@@ -1035,25 +1058,16 @@ class IndexView(AdminIndexView):
             )
         else:
             package_count = _maintainer_filter(Package.query).count()
-            build_count = (
-                _maintainer_filter(
-                    Build.query.join(Build.version).join(Version.package)
-                )
-                .filter(User.id == current_user.id)
-                .count()
-            )
-            inactive_build_count = (
-                _maintainer_filter(
-                    Build.query.filter_by(active=False)
-                    .join(Build.version)
-                    .join(Version.package)
-                )
-                .filter(User.id == current_user.id)
-                .count()
-            )
+            build_count = _maintainer_filter(
+                Build.query.join(Build.version).join(Version.package)
+            ).count()
+            inactive_build_count = _maintainer_filter(
+                Build.query.filter_by(active=False)
+                .join(Build.version)
+                .join(Version.package)
+            ).count()
             recent_versions = (
                 _maintainer_filter(Version.query.join(Version.package))
-                .filter(User.id == current_user.id)
                 .order_by(Version.insert_date.desc())
                 .limit(5)
                 .all()


### PR DESCRIPTION
## Description

- Admin: permissions, resync access, unsign guard, and total_size sorting

**Permissions**
- Extended `can_resync_info` and `can_resync_file` in `SignResyncMixin` to allow `package_admin` in addition to `admin`, covering both `VersionView` and `BuildView`. Sign and unsign remain `admin`-only.
- `package_admin` is a global role with full visibility over all packages, so resync access is consistent with what they can already see and do.

**Unsign guard**
- `action_unsign` now skips active builds with a warning flash message requiring deactivation first, preventing a build from being left publicly served without a signature.

**Bug fixes**
- `VersionView._iter_builds` now guards against `None` build paths, matching the existing defensive pattern in `BuildView._iter_builds`, preventing a `TypeError` during sign/unsign/resync actions on builds with no path.
- `IndexView` had a redundant `User.id == current_user.id` filter applied after `_maintainer_filter` in three queries (`build_count`, `inactive_build_count`, `recent_versions`) — removed the duplicates.
- `ScreenshotView.on_model_delete` used the variable name `build_path` — renamed to `screenshot_path`.
- `UserView` was not busting the `packages_versions` cache after model changes and deletes — added `after_model_change` and `after_model_delete` hooks for consistency with `PackageView` and `BuildView`.

**`Version.total_size` sorting and filtering**
- Converted `Version.total_size` from a plain `@property` to a `@hybrid_property` with a SQL-side scalar subquery expression, enabling Flask-Admin to sort and filter on it. Added `total_size` to `column_sortable_list` and `column_filters` in `VersionView`. No schema changes required.

**Tests**
- Updated resync permission tests in `VersionTestCase` and `BuildTestCase` to reflect `package_admin` access, replacing the old `_requires_admin` and `_blocked_for_non_admin` tests with a consistent set covering visibility, POST success, and `developer` still being blocked.
- Added tests for the unsign active-build guard and confirming sign/unsign remain `admin`-only.