### PR TITLE
Admin: download insights, architecture breakdown, and dashboard improvements

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -655,6 +655,30 @@ class Version(db.Model):
         )
 
 
+Version.download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .join(Build, Build.id == DownloadStat.build_id)
+    .where(Build.version_id == Version.id)
+    .correlate(Version)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+Version.recent_download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .join(Build, Build.id == DownloadStat.build_id)
+    .where(
+        db.and_(
+            Build.version_id == Version.id,
+            DownloadStat.date >= _days_ago(90),
+        )
+    )
+    .correlate(Version)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+
 class Package(db.Model):
     __tablename__ = "package"
 

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -682,6 +682,12 @@ class Package(db.Model):
         .scalar_subquery(),
         deferred=True,
     )
+    last_download_date = db.column_property(
+        db.select(db.func.max(DownloadStat.date))
+        .where(DownloadStat.package_id == id)
+        .scalar_subquery(),
+        deferred=True,
+    )
 
     # Relationships
     versions = db.relationship(

--- a/spkrepo/templates/admin/index.html
+++ b/spkrepo/templates/admin/index.html
@@ -71,6 +71,7 @@
               <th>Version</th>
               <th>Total Size</th>
               <th>All Active</th>
+              <th>Downloads (90d)</th>
               <th>Date</th>
             </tr>
           </thead>
@@ -87,11 +88,12 @@
                   <i class="fa fa-times-circle" style="color: #e74c3c;"></i>
                 {% endif %}
               </td>
-              <td>{{ version.insert_date.strftime('%Y-%m-%d %H:%M') }}</td>
+              <td>{{ "{:,}".format(version.recent_download_count) if version.recent_download_count else '—' }}</td>
+              <td>{{ version.insert_date.strftime('%Y-%m-%d') }}</td>
             </tr>
             {% else %}
             <tr>
-              <td colspan="5" class="text-center text-muted">No versions uploaded yet.</td>
+              <td colspan="6" class="text-center text-muted">No versions uploaded yet.</td>
             </tr>
             {% endfor %}
           </tbody>

--- a/spkrepo/templates/admin/package_detail.html
+++ b/spkrepo/templates/admin/package_detail.html
@@ -1,0 +1,74 @@
+{% extends 'admin/master.html' %}
+{% import 'admin/lib.html' as lib with context %}
+
+{% block body %}
+  {% block navlinks %}
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+      <a class="nav-link" href="{{ return_url }}">{{ _gettext('List') }}</a>
+    </li>
+    {%- if admin_view.can_create -%}
+    <li class="nav-item">
+      <a class="nav-link" href="{{ get_url('.create_view', url=return_url) }}">{{ _gettext('Create') }}</a>
+    </li>
+    {%- endif -%}
+    {%- if admin_view.can_edit -%}
+    <li class="nav-item">
+      <a class="nav-link" href="{{ get_url('.edit_view', id=request.args.get('id'), url=return_url) }}">{{ _gettext('Edit') }}</a>
+    </li>
+    {%- endif -%}
+    <li class="nav-item">
+      <a class="nav-link active disabled" href="javascript:void(0)">{{ _gettext('Details') }}</a>
+    </li>
+  </ul>
+  {% endblock %}
+
+  {% block details_search %}
+    <div class="form-inline fa_filter_container col-lg-6">
+      <label for="fa_filter">{{ _gettext('Filter') }}</label>
+      <input id="fa_filter" type="text" class="ml-3 form-control">
+    </div>
+  {% endblock %}
+
+  {% block details_table %}
+    <table class="table table-hover table-bordered searchable">
+      {% for c, name in details_columns %}
+        <tr>
+          <td><b>{% if c == 'recent_download_count' %}Recent Downloads (90d){% else %}{{ name }}{% endif %}</b></td>
+          <td>
+            {% if c == 'arch_breakdown' %}
+              {% if arch_breakdown %}
+                <table style="width: 100%; max-width: 380px; border: none; border-spacing: 0">
+                  {% for code, count, pct in arch_breakdown %}
+                    <tr>
+                      <td style="white-space: nowrap; padding-right: 10px; font-family: monospace; width: 1%">
+                        {{ code }}
+                      </td>
+                      <td style="width: 100%; padding-right: 10px">
+                        <div style="background: #e9ecef; border-radius: 3px; height: 14px">
+                          <div style="background: #5b9bd5; border-radius: 3px; height: 14px; width: {{ pct | round(1) }}%"></div>
+                        </div>
+                      </td>
+                      <td style="white-space: nowrap; color: #666; font-size: 0.9em">
+                        {{ "{:,}".format(count) }} ({{ pct | round | int }}%)
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </table>
+              {% else %}
+                <span class="text-muted">No downloads in the last 90 days</span>
+              {% endif %}
+            {% else %}
+              {{ get_value(model, c) }}
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  {% endblock %}
+{% endblock %}
+
+{% block tail %}
+  {{ super() }}
+  <script {{ admin_csp_nonce_attribute }} src="{{ admin_static.url(filename='admin/js/details_filter.js', v='1.0.0') }}"></script>
+{% endblock %}

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -2,6 +2,7 @@
 import io
 import os
 import shutil
+from datetime import date, timedelta
 
 from flask import abort, current_app, flash, redirect, request, url_for
 from flask_admin import AdminIndexView, expose
@@ -23,6 +24,7 @@ from ..models import (
     BuildManifest,
     Description,
     DisplayName,
+    DownloadStat,
     Firmware,
     Icon,
     Language,
@@ -668,12 +670,49 @@ class PackageView(ModelView):
     def after_model_delete(self, model):
         cache.delete("packages_versions")
 
+    can_view_details = True
+    details_template = "admin/package_detail.html"
+
+    @expose("/details/")
+    def details_view(self):
+        self._template_args["arch_breakdown"] = self._get_arch_breakdown()
+        return super().details_view()
+
+    def _get_arch_breakdown(self):
+        from flask import request as flask_request
+
+        pkg_id = flask_request.args.get("id", type=int)
+        if not pkg_id:
+            return None
+        cutoff = date.today() - timedelta(days=90)
+        rows = db.session.execute(
+            db.select(
+                Architecture.code,
+                db.func.sum(DownloadStat.count).label("total"),
+            )
+            .join(Architecture, Architecture.id == DownloadStat.architecture_id)
+            .where(
+                db.and_(
+                    DownloadStat.package_id == pkg_id,
+                    DownloadStat.date >= cutoff,
+                )
+            )
+            .group_by(Architecture.code)
+            .order_by(db.desc("total"))
+            .limit(3)
+        ).all()
+        if not rows:
+            return None
+        grand_total = sum(total for _, total in rows)
+        return [(code, total, total / grand_total * 100) for code, total in rows]
+
     column_list = (
         "name",
         "author",
         "maintainers",
         "download_count",
         "recent_download_count",
+        "last_download_date",
         "insert_date",
     )
     column_sortable_list = (
@@ -682,22 +721,44 @@ class PackageView(ModelView):
         ("insert_date", "insert_date"),
         ("download_count", "download_count"),
         ("recent_download_count", "recent_download_count"),
+        ("last_download_date", "last_download_date"),
     )
     column_formatters = {
-        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
+        "insert_date": lambda v, c, m, p: (
+            m.insert_date.strftime("%Y-%m-%d") if m.insert_date else None
+        ),
         "download_count": lambda v, c, m, p: (
             f"{m.download_count:,}" if m.download_count else "0"
         ),
         "recent_download_count": lambda v, c, m, p: (
             f"{m.recent_download_count:,}" if m.recent_download_count else "0"
         ),
+        "last_download_date": lambda v, c, m, p: (
+            m.last_download_date.strftime("%Y-%m-%d") if m.last_download_date else None
+        ),
+    }
+
+    column_formatters_detail = {
+        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
     }
     column_labels = {
         "download_count": "Downloads",
         "recent_download_count": "Recent Downloads",
+        "last_download_date": "Last Download",
         "author.username": "Author",
+        "arch_breakdown": "Top Architectures (90d)",
     }
     column_filters = ("name", "author.username")
+    column_details_list = (
+        "name",
+        "author",
+        "maintainers",
+        "insert_date",
+        "download_count",
+        "recent_download_count",
+        "last_download_date",
+        "arch_breakdown",
+    )
 
     form_columns = ("name", "author", "maintainers")
     form_args = {"name": {"validators": [Regexp(SPK.package_re)]}}
@@ -782,7 +843,9 @@ class VersionView(SignResyncMixin, ModelView):
         ("total_size", "total_size"),
     )
     column_formatters = {
-        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
+        "insert_date": lambda v, c, m, p: (
+            m.insert_date.strftime("%Y-%m-%d") if m.insert_date else None
+        ),
         "all_builds_active": _bool_formatter,
         "startable": _bool_formatter,
         "beta": _bool_formatter,
@@ -791,6 +854,7 @@ class VersionView(SignResyncMixin, ModelView):
         ),
     }
     column_formatters_detail = {
+        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
         "install_wizard": _bool_formatter,
         "upgrade_wizard": _bool_formatter,
         "startable": _bool_formatter,
@@ -944,11 +1008,16 @@ class BuildView(SignResyncMixin, ModelView):
         ("active", "active"),
     )
     column_formatters = {
-        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
+        "insert_date": lambda v, c, m, p: (
+            m.insert_date.strftime("%Y-%m-%d") if m.insert_date else None
+        ),
         "size": lambda v, c, m, p: (
             f"{m.size / 1024 / 1024:.1f} MB" if m.size else None
         ),
         "active": _bool_formatter,
+    }
+    column_formatters_detail = {
+        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
     }
     column_default_sort = (Build.insert_date, True)
 

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -823,6 +823,8 @@ class VersionView(SignResyncMixin, ModelView):
         "install_wizard": "Install Wizard",
         "upgrade_wizard": "Upgrade Wizard",
         "total_size": "Total Size",
+        "download_count": "Downloads",
+        "recent_download_count": "Recent Downloads (90d)",
     }
     column_filters = (
         "package.name",
@@ -859,6 +861,12 @@ class VersionView(SignResyncMixin, ModelView):
         "upgrade_wizard": _bool_formatter,
         "startable": _bool_formatter,
         "license": _truncate_formatter,
+        "download_count": lambda v, c, m, p: (
+            f"{m.download_count:,}" if m.download_count else "0"
+        ),
+        "recent_download_count": lambda v, c, m, p: (
+            f"{m.recent_download_count:,}" if m.recent_download_count else "0"
+        ),
     }
     column_default_sort = (Version.insert_date, True)
 


### PR DESCRIPTION
## Description

- Add download insights, architecture breakdown, and date formatting consistency to admin views

**Package model**
- Added `last_download_date` as a deferred `column_property` scalar subquery
- No schema changes required

**Version model**
- Added `download_count` and `recent_download_count` as deferred `column_property` scalar subqueries joining through `Build` to `DownloadStat`
- No schema changes required

**Package list view**
- Added sortable `last_download_date` column for identifying dormant packages
- `insert_date` trimmed to date-only for consistency, full timestamp in detail view

**Package detail view**
- Enabled `can_view_details` with a custom detail template
- Architecture breakdown showing top 3 architectures by download share over the last 90 days, rendered as proportional bar chart rows
- Full timestamps and "(90d)" label shown in the detail view

**Version detail view**
- `download_count` and `recent_download_count` now visible in the detail panel

**Version and build list views**
- `insert_date` trimmed to date-only, consistent with package view

**Dashboard**
- Added "Downloads (90d)" column to the Last 5 Versions Uploaded table
- `insert_date` trimmed to date-only