### PR TITLE
Admin: enforce SPK version-level metadata consistency and harden resync path

### DIFF
--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -337,6 +337,48 @@ class VersionTestCase(BaseTestCase):
         )
         self.assertEqual(refreshed_build.md5, refreshed_build.calculate_md5())
 
+    def test_action_resync_info_invalidates_cache(self):
+        build = BuildFactory()
+        db.session.commit()
+        from spkrepo.ext import cache as app_cache
+
+        app_cache.set("packages_versions", "stale")
+        with self.logged_user("package_admin", "admin"):
+            self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build.version.id]),
+            )
+        self.assertIsNone(app_cache.get("packages_versions"))
+
+    def test_action_resync_file_invalidates_cache(self):
+        build = BuildFactory()
+        db.session.commit()
+        from spkrepo.ext import cache as app_cache
+
+        app_cache.set("packages_versions", "stale")
+        with self.logged_user("package_admin", "admin"):
+            self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_file", rowid=[build.version.id]),
+            )
+        self.assertIsNone(app_cache.get("packages_versions"))
+
+    def test_action_resync_info_single_build_no_siblings_succeeds(self):
+        # A version with only one build must resync cleanly with no sibling check.
+        build = BuildFactory()
+        db.session.commit()
+        self.assertEqual(len(build.version.builds), 1)
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build.version.id]),
+            )
+        self.assert200(response)
+        self.assertIn("refreshed", response.data.decode())
+
     def test_action_resync_info_rejects_inconsistent_sibling_builds(self):
         # If two builds under the same version have different version-level metadata
         # on disk, resync must fail with an error rather than silently overwriting.
@@ -677,6 +719,48 @@ class BuildTestCase(BaseTestCase):
             original_architectures,
         )
 
+    def test_action_resync_info_single_build_no_siblings_succeeds(self):
+        # A build with no siblings must resync cleanly.
+        build = BuildFactory()
+        db.session.commit()
+        self.assertEqual(len(build.version.builds), 1)
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build.id]),
+            )
+        self.assert200(response)
+        self.assertIn("refreshed", response.data.decode())
+
+    def test_action_resync_info_invalidates_cache(self):
+        build = BuildFactory()
+        db.session.commit()
+        from spkrepo.ext import cache as app_cache
+
+        app_cache.set("packages_versions", "stale")
+        with self.logged_user("package_admin", "admin"):
+            self.client.post(
+                url_for("build.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build.id]),
+            )
+        self.assertIsNone(app_cache.get("packages_versions"))
+
+    def test_action_resync_file_invalidates_cache(self):
+        build = BuildFactory()
+        db.session.commit()
+        from spkrepo.ext import cache as app_cache
+
+        app_cache.set("packages_versions", "stale")
+        with self.logged_user("package_admin", "admin"):
+            self.client.post(
+                url_for("build.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_file", rowid=[build.id]),
+            )
+        self.assertIsNone(app_cache.get("packages_versions"))
+
     def test_action_resync_info_rejects_inconsistent_sibling_build(self):
         # Resyncing a single build must fail if its sibling SPK has different
         # version-level metadata, to prevent last-write-wins corruption.
@@ -684,16 +768,36 @@ class BuildTestCase(BaseTestCase):
         build2 = BuildFactory(version=build1.version)
         db.session.commit()
 
-        # Overwrite build2's SPK on disk with a displayname that differs
-        # from what is stored in the DB (and from build1's SPK).
-        existing_displayname = build1.version.displaynames["enu"].displayname
-        info = create_info(build2)
-        info["displayname"] = existing_displayname + " SIBLING MODIFIED"
-        info["displayname_enu"] = existing_displayname + " SIBLING MODIFIED"
-        spk_path = os.path.join(current_app.config["DATA_PATH"], build2.path)
-        with open(spk_path, "wb") as f:
-            with create_spk(build2, info=info) as spk:
+        # Build build2's info independently and set a displayname that is
+        # guaranteed to differ from what build1's SPK contains on disk.
+        # We must override both the bare and the suffixed key because create_info
+        # emits both "displayname" and "displayname_enu".
+        original_displayname = build1.version.displaynames["enu"].displayname
+        modified_displayname = original_displayname + " SIBLING MODIFIED"
+
+        info2 = create_info(build2)
+        info2["displayname"] = modified_displayname
+        info2["displayname_enu"] = modified_displayname
+
+        spk2_path = os.path.join(current_app.config["DATA_PATH"], build2.path)
+        with open(spk2_path, "wb") as f:
+            with create_spk(build2, info=info2) as spk:
                 f.write(spk.read())
+
+        # Sanity check: build1's SPK on disk must still have the original name.
+        from spkrepo.utils import SPK, extract_version_metadata
+        import io as _io
+
+        spk1_path = os.path.join(current_app.config["DATA_PATH"], build1.path)
+        with _io.open(spk1_path, "rb") as f:
+            meta1 = extract_version_metadata(SPK(f))
+        with _io.open(spk2_path, "rb") as f:
+            meta2 = extract_version_metadata(SPK(f))
+        self.assertNotEqual(
+            meta1["displaynames"],
+            meta2["displaynames"],
+            "Precondition failed: SPK files must differ before running resync",
+        )
 
         with self.logged_user("package_admin", "admin"):
             response = self.client.post(

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -785,8 +785,9 @@ class BuildTestCase(BaseTestCase):
                 f.write(spk.read())
 
         # Sanity check: build1's SPK on disk must still have the original name.
-        from spkrepo.utils import SPK, extract_version_metadata
         import io as _io
+
+        from spkrepo.utils import SPK, extract_version_metadata
 
         spk1_path = os.path.join(current_app.config["DATA_PATH"], build1.path)
         with _io.open(spk1_path, "rb") as f:

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -11,6 +11,8 @@ from spkrepo.tests.common import (
     PackageFactory,
     VersionFactory,
     create_image,
+    create_info,
+    create_spk,
 )
 
 
@@ -274,8 +276,7 @@ class VersionTestCase(BaseTestCase):
 
     def test_action_resync_info_refreshes_build_metadata(self):
         # Pin firmware_min to the lowest seeded firmware so we can always find
-        # a different one to corrupt the build with, making the
-        # restore assertion meaningful.
+        # a different one to corrupt the build with.
         build = BuildFactory(
             firmware_min=Firmware.query.order_by(Firmware.build.asc()).first(),
             firmware_max=Firmware.query.order_by(Firmware.build.desc()).first(),
@@ -289,7 +290,7 @@ class VersionTestCase(BaseTestCase):
         original_dependencies = build.buildmanifest.dependencies
         original_conf_privilege = build.buildmanifest.conf_privilege
 
-        # Corrupt the build — use a firmware that is guaranteed to differ
+        # Corrupt the build
         corrupting_firmware = Firmware.query.filter(
             Firmware.id != original_firmware_min.id
         ).first()
@@ -304,7 +305,6 @@ class VersionTestCase(BaseTestCase):
 
         db.session.commit()
 
-        # Verify the corruption took effect so we know the resync is actually doing work
         self.assertNotEqual(build.firmware_min.id, original_firmware_min.id)
         self.assertIsNone(build.firmware_max)
 
@@ -325,7 +325,6 @@ class VersionTestCase(BaseTestCase):
             original_architectures,
         )
         self.assertEqual(refreshed_build.firmware_min.id, original_firmware_min.id)
-        # firmware_max was set to a known value and should be restored
         self.assertIsNotNone(refreshed_build.firmware_max)
         self.assertEqual(refreshed_build.firmware_max.id, original_firmware_max.id)
         self.assertEqual(
@@ -337,6 +336,35 @@ class VersionTestCase(BaseTestCase):
             original_conf_privilege,
         )
         self.assertEqual(refreshed_build.md5, refreshed_build.calculate_md5())
+
+    def test_action_resync_info_rejects_inconsistent_sibling_builds(self):
+        # If two builds under the same version have different version-level metadata
+        # on disk, resync must fail with an error rather than silently overwriting.
+        build1 = BuildFactory()
+        build2 = BuildFactory(version=build1.version)
+        db.session.commit()
+
+        # Overwrite build2's SPK on disk with a displayname that differs
+        # from what is in the DB (and from build1's SPK).
+        existing_displayname = build1.version.displaynames["enu"].displayname
+        info = create_info(build2)
+        info["displayname"] = existing_displayname + " SIBLING MODIFIED"
+        info["displayname_enu"] = existing_displayname + " SIBLING MODIFIED"
+        spk_path = os.path.join(current_app.config["DATA_PATH"], build2.path)
+        with open(spk_path, "wb") as f:
+            with create_spk(build2, info=info) as spk:
+                f.write(spk.read())
+
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("version.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build1.version.id]),
+            )
+        self.assert200(response)
+        # The flash message must report failure, not success.
+        self.assertIn("Failed", response.data.decode())
+        self.assertNotIn("refreshed", response.data.decode())
 
     def test_action_resync_file_visible_to_package_admin(self):
         with self.logged_user("package_admin"):
@@ -649,6 +677,34 @@ class BuildTestCase(BaseTestCase):
             original_architectures,
         )
 
+    def test_action_resync_info_rejects_inconsistent_sibling_build(self):
+        # Resyncing a single build must fail if its sibling SPK has different
+        # version-level metadata, to prevent last-write-wins corruption.
+        build1 = BuildFactory()
+        build2 = BuildFactory(version=build1.version)
+        db.session.commit()
+
+        # Overwrite build2's SPK on disk with a displayname that differs
+        # from what is stored in the DB (and from build1's SPK).
+        existing_displayname = build1.version.displaynames["enu"].displayname
+        info = create_info(build2)
+        info["displayname"] = existing_displayname + " SIBLING MODIFIED"
+        info["displayname_enu"] = existing_displayname + " SIBLING MODIFIED"
+        spk_path = os.path.join(current_app.config["DATA_PATH"], build2.path)
+        with open(spk_path, "wb") as f:
+            with create_spk(build2, info=info) as spk:
+                f.write(spk.read())
+
+        with self.logged_user("package_admin", "admin"):
+            response = self.client.post(
+                url_for("build.action_view"),
+                follow_redirects=True,
+                data=dict(action="resync_info", rowid=[build1.id]),
+            )
+        self.assert200(response)
+        self.assertIn("Failed", response.data.decode())
+        self.assertNotIn("refreshed", response.data.decode())
+
     def test_action_resync_file_visible_to_package_admin(self):
         with self.logged_user("package_admin"):
             response = self.client.get(url_for("build.index_view"))
@@ -770,7 +826,7 @@ class BuildTestCase(BaseTestCase):
         # A developer who is a maintainer on a package sees only that package's builds.
         with self.logged_user("developer") as user:
             own_package = PackageFactory(maintainers=[user])
-            BuildFactory(version__package=own_package)  # creates the build on disk
+            BuildFactory(version__package=own_package)
             other_build = BuildFactory()
             db.session.commit()
             response = self.client.get(url_for("build.index_view"))
@@ -820,8 +876,6 @@ class ScreenshotDeleteTestCase(BaseTestCase):
     def test_delete_removes_file(self):
         package = PackageFactory(add_screenshot=False)
         db.session.commit()
-        # Use a single logged_user context so create and delete are performed
-        # by the same user, matching the normal admin workflow.
         with self.logged_user("package_admin"):
             self.client.post(
                 url_for("screenshot.create_view"),

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -6,6 +6,7 @@ from flask import current_app, url_for
 from spkrepo.ext import db
 from spkrepo.models import Build, Firmware, Package, Version
 from spkrepo.tests.common import (
+    Architecture,
     BaseTestCase,
     BuildFactory,
     PackageFactory,
@@ -382,12 +383,21 @@ class VersionTestCase(BaseTestCase):
     def test_action_resync_info_rejects_inconsistent_sibling_builds(self):
         # If two builds under the same version have different version-level metadata
         # on disk, resync must fail with an error rather than silently overwriting.
-        build1 = BuildFactory()
-        build2 = BuildFactory(version=build1.version)
+        # Pin to distinct architectures so Build.generate_filename produces
+        # different paths for each build — otherwise one SPK overwrites the other.
+        build1 = BuildFactory(architectures=[Architecture.find("88f628x")])
+        build2 = BuildFactory(
+            version=build1.version,
+            architectures=[Architecture.find("cedarview")],
+        )
         db.session.commit()
 
-        # Overwrite build2's SPK on disk with a displayname that differs
-        # from what is in the DB (and from build1's SPK).
+        self.assertNotEqual(
+            build1.path,
+            build2.path,
+            "Precondition failed: builds must have different SPK paths",
+        )
+
         existing_displayname = build1.version.displaynames["enu"].displayname
         info = create_info(build2)
         info["displayname"] = existing_displayname + " SIBLING MODIFIED"
@@ -764,14 +774,22 @@ class BuildTestCase(BaseTestCase):
     def test_action_resync_info_rejects_inconsistent_sibling_build(self):
         # Resyncing a single build must fail if its sibling SPK has different
         # version-level metadata, to prevent last-write-wins corruption.
-        build1 = BuildFactory()
-        build2 = BuildFactory(version=build1.version)
+        # Pin to distinct architectures so Build.generate_filename produces
+        # different paths for each build — otherwise one SPK overwrites the other.
+        build1 = BuildFactory(architectures=[Architecture.find("88f628x")])
+        build2 = BuildFactory(
+            version=build1.version,
+            architectures=[Architecture.find("cedarview")],
+        )
         db.session.commit()
 
-        # Build build2's info independently and set a displayname that is
-        # guaranteed to differ from what build1's SPK contains on disk.
-        # We must override both the bare and the suffixed key because create_info
-        # emits both "displayname" and "displayname_enu".
+        # Verify the two builds have different paths on disk.
+        self.assertNotEqual(
+            build1.path,
+            build2.path,
+            "Precondition failed: builds must have different SPK paths",
+        )
+
         original_displayname = build1.version.displaynames["enu"].displayname
         modified_displayname = original_displayname + " SIBLING MODIFIED"
 

--- a/spkrepo/tests/test_api.py
+++ b/spkrepo/tests/test_api.py
@@ -562,7 +562,8 @@ class PackagesTestCase(BaseTestCase):
         self.assert422(response)
         self.assertIn("Invalid SPK", response.data.decode())
 
-    def test_post_existing_version_matching_upstream(self):
+    def test_post_existing_version_matching_metadata(self):
+        # A second build for the same version with identical metadata must succeed.
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
         db.session.commit()
 
@@ -593,6 +594,7 @@ class PackagesTestCase(BaseTestCase):
             )
 
     def test_post_existing_version_mismatched_upstream(self):
+        # A second build with a different upstream_version must be rejected with 422.
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
         db.session.commit()
 
@@ -622,7 +624,122 @@ class PackagesTestCase(BaseTestCase):
                 data=spk.read(),
             )
         self.assert422(response)
-        self.assertIn("Upstream version mismatch", response.data.decode())
+        self.assertIn("upstream_version", response.data.decode())
+
+    def test_post_existing_version_mismatched_displayname_rejected(self):
+        # A second build with a different displayname must be rejected with 422.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(
+            architectures=[Architecture.find("88f628x")],
+        )
+        with create_spk(build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+        # Fetch the persisted version from the DB.
+        persisted_version = Build.query.one().version
+        existing_displayname = persisted_version.displaynames["enu"].displayname
+
+        # Second build: different arch to avoid conflict, modified displayname AND
+        # displayname_enu so the bare key is not shadowed by the suffixed key.
+        new_build = BuildFactory.build(
+            version=persisted_version,
+            architectures=[Architecture.find("cedarview")],
+        )
+        info = create_info(new_build)
+        info["displayname"] = existing_displayname + " MODIFIED"
+        info["displayname_enu"] = existing_displayname + " MODIFIED"
+        with create_spk(new_build, info=info) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert422(response)
+        self.assertIn("displaynames", response.data.decode())
+
+    def test_post_existing_version_mismatched_changelog_rejected(self):
+        # A second build with a different changelog must be rejected with 422.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(
+            architectures=[Architecture.find("88f628x")],
+        )
+        with create_spk(build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+        persisted_version = Build.query.one().version
+        existing_changelog = persisted_version.changelog or ""
+
+        new_build = BuildFactory.build(
+            version=persisted_version,
+            architectures=[Architecture.find("cedarview")],
+        )
+        info = create_info(new_build)
+        info["changelog"] = existing_changelog + " MODIFIED"
+        with create_spk(new_build, info=info) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert422(response)
+        self.assertIn("changelog", response.data.decode())
+
+    def test_post_existing_version_metadata_mismatch_does_not_persist(self):
+        # A rejected upload must not partially modify the DB.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(
+            architectures=[Architecture.find("88f628x")],
+        )
+        with create_spk(build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+        persisted_version = Build.query.one().version
+        original_displayname = persisted_version.displaynames["enu"].displayname
+
+        new_build = BuildFactory.build(
+            version=persisted_version,
+            architectures=[Architecture.find("cedarview")],
+        )
+        info = create_info(new_build)
+        info["displayname"] = original_displayname + " MODIFIED"
+        info["displayname_enu"] = original_displayname + " MODIFIED"
+        with create_spk(new_build, info=info) as spk:
+            response = self.client.post(
+                url_for("api.packages"),
+                headers=authorization_header(user),
+                data=spk.read(),
+            )
+        self.assert422(response)
+
+        db.session.expire_all()
+        self.assertEqual(
+            Build.query.one().version.displaynames["enu"].displayname,
+            original_displayname,
+        )
 
     def test_post_201_response_body(self):
         # The 201 response body must contain package, version, firmware, architectures.
@@ -680,7 +797,7 @@ class PackagesTestCase(BaseTestCase):
                 data=spk.read(),
             )
         self.assert422(response)
-        self.assertIn("Invalid maximum firmware", response.data.decode())
+        self.assertIn("Invalid firmware value", response.data.decode())
 
     def test_post_unknown_firmware_max(self):
         # os_max_ver with valid format but unknown build number returns 422.
@@ -697,7 +814,7 @@ class PackagesTestCase(BaseTestCase):
                 data=spk.read(),
             )
         self.assert422(response)
-        self.assertIn("Unknown maximum firmware", response.data.decode())
+        self.assertIn("Unknown firmware", response.data.decode())
 
     def test_post_firmware_max_less_than_firmware_min(self):
         # os_max_ver < firmware returns 422.

--- a/spkrepo/tests/test_utils.py
+++ b/spkrepo/tests/test_utils.py
@@ -15,7 +15,11 @@ from spkrepo.tests.common import (
     create_info,
     create_spk,
 )
-from spkrepo.utils import SPK
+from spkrepo.utils import (
+    SPK,
+    extract_version_metadata,
+    assert_version_metadata_matches_db,
+)
 
 
 class SPKParseTestCase(BaseTestCase):
@@ -381,6 +385,177 @@ class SPKUnsignTestCase(BaseTestCase):
         with self.assertRaises(ValueError) as cm:
             spk.unsign()
         self.assertEqual("Not signed", str(cm.exception))
+
+
+class ExtractVersionMetadataTestCase(BaseTestCase):
+    """Tests for extract_version_metadata — pure dict extraction, no DB writes."""
+
+    def test_displaynames_keyed_by_language_code(self):
+        # INFO key "displayname" must map to "enu", not the raw key name.
+        build = BuildFactory.build()
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        self.assertIn("enu", meta["displaynames"])
+        self.assertNotIn("displayname", meta["displaynames"])
+        self.assertEqual(
+            meta["displaynames"]["enu"],
+            build.version.displaynames["enu"].displayname,
+        )
+
+    def test_descriptions_keyed_by_language_code(self):
+        # INFO key "description" must map to "enu", not the raw key name.
+        build = BuildFactory.build()
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        self.assertIn("enu", meta["descriptions"])
+        self.assertNotIn("description", meta["descriptions"])
+        self.assertEqual(
+            meta["descriptions"]["enu"],
+            build.version.descriptions["enu"].description,
+        )
+
+    def test_startable_defaults_true(self):
+        build = BuildFactory.build(version__startable=None)
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        self.assertTrue(meta["startable"])
+
+    def test_startable_false_when_ctl_stop_false(self):
+        build = BuildFactory.build(version__startable=False)
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        self.assertFalse(meta["startable"])
+
+    def test_install_dep_services_as_set(self):
+        build = BuildFactory.build()
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        expected = {s.code for s in build.version.service_dependencies}
+        self.assertEqual(meta["install_dep_services"], expected)
+
+    def test_no_services_returns_empty_set(self):
+        build = BuildFactory.build(version__service_dependencies=[])
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        self.assertEqual(meta["install_dep_services"], set())
+
+    def test_upstream_version_extracted(self):
+        build = BuildFactory.build(version__upstream_version="1.2.3")
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        self.assertEqual(meta["upstream_version"], "1.2.3")
+
+    def test_install_wizard_reflected(self):
+        build = BuildFactory.build(version__install_wizard=True)
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        self.assertTrue(meta["install_wizard"])
+
+    def test_upgrade_wizard_reflected(self):
+        build = BuildFactory.build(version__upgrade_wizard=True)
+        with create_spk(build) as f:
+            spk = SPK(f)
+        meta = extract_version_metadata(spk)
+        self.assertTrue(meta["upgrade_wizard"])
+
+
+class AssertVersionMetadataMatchesDBTestCase(BaseTestCase):
+    """Tests for assert_version_metadata_matches_db."""
+
+    def test_matching_spk_does_not_raise(self):
+        # An SPK whose metadata exactly matches the DB version must pass silently.
+        build = BuildFactory()
+        db.session.commit()
+        with create_spk(build) as f:
+            spk = SPK(f)
+        # Should not raise
+        assert_version_metadata_matches_db(build.version, spk)
+
+    def test_mismatched_displayname_raises(self):
+        build = BuildFactory()
+        db.session.commit()
+        existing = build.version.displaynames["enu"].displayname
+        info = create_info(build)
+        info["displayname"] = existing + " MODIFIED"
+        info["displayname_enu"] = existing + " MODIFIED"
+        with create_spk(build, info=info) as f:
+            spk = SPK(f)
+        with self.assertRaises(ValueError) as cm:
+            assert_version_metadata_matches_db(build.version, spk)
+        self.assertIn("displaynames", str(cm.exception))
+
+    def test_mismatched_description_raises(self):
+        build = BuildFactory()
+        db.session.commit()
+        existing = build.version.descriptions["enu"].description
+        info = create_info(build)
+        info["description"] = existing + " MODIFIED"
+        info["description_enu"] = existing + " MODIFIED"
+        with create_spk(build, info=info) as f:
+            spk = SPK(f)
+        with self.assertRaises(ValueError) as cm:
+            assert_version_metadata_matches_db(build.version, spk)
+        self.assertIn("descriptions", str(cm.exception))
+
+    def test_mismatched_upstream_version_raises(self):
+        build = BuildFactory(version__upstream_version="1.0.0")
+        db.session.commit()
+        info = create_info(build)
+        info["version"] = f"2.0.0-{build.version.version}"
+        with create_spk(build, info=info) as f:
+            spk = SPK(f)
+        with self.assertRaises(ValueError) as cm:
+            assert_version_metadata_matches_db(build.version, spk)
+        self.assertIn("upstream_version", str(cm.exception))
+
+    def test_mismatched_changelog_raises(self):
+        build = BuildFactory()
+        db.session.commit()
+        existing = build.version.changelog or ""
+        info = create_info(build)
+        info["changelog"] = existing + " MODIFIED"
+        with create_spk(build, info=info) as f:
+            spk = SPK(f)
+        with self.assertRaises(ValueError) as cm:
+            assert_version_metadata_matches_db(build.version, spk)
+        self.assertIn("changelog", str(cm.exception))
+
+    def test_mismatched_service_dependencies_raises(self):
+        build = BuildFactory(version__service_dependencies=[])
+        db.session.commit()
+        info = create_info(build)
+        info["install_dep_services"] = "apache-web"
+        with create_spk(build, info=info) as f:
+            spk = SPK(f)
+        with self.assertRaises(ValueError) as cm:
+            assert_version_metadata_matches_db(build.version, spk)
+        self.assertIn("service_dependencies", str(cm.exception))
+
+    def test_error_message_lists_all_mismatches(self):
+        # Multiple mismatching fields should all appear in the error message.
+        build = BuildFactory()
+        db.session.commit()
+        existing_displayname = build.version.displaynames["enu"].displayname
+        existing_changelog = build.version.changelog or ""
+        info = create_info(build)
+        info["displayname"] = existing_displayname + " MODIFIED"
+        info["displayname_enu"] = existing_displayname + " MODIFIED"
+        info["changelog"] = existing_changelog + " MODIFIED"
+        with create_spk(build, info=info) as f:
+            spk = SPK(f)
+        with self.assertRaises(ValueError) as cm:
+            assert_version_metadata_matches_db(build.version, spk)
+        error = str(cm.exception)
+        self.assertIn("displaynames", error)
+        self.assertIn("changelog", error)
 
 
 class PopulateDBTestCase(BaseTestCase):

--- a/spkrepo/tests/test_utils.py
+++ b/spkrepo/tests/test_utils.py
@@ -17,8 +17,8 @@ from spkrepo.tests.common import (
 )
 from spkrepo.utils import (
     SPK,
-    extract_version_metadata,
     assert_version_metadata_matches_db,
+    extract_version_metadata,
 )
 
 

--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -565,6 +565,18 @@ def apply_info_from_spk(session, build, spk, md5_hash):
     unconditionally — callers must ensure consistency has already been checked
     via :func:`assert_version_metadata_matches_db` before calling this.
 
+    .. note::
+        Icon files are written to disk before the database is flushed. If a
+        subsequent error causes the caller to roll back the session, any newly
+        written icon files will be left on disk. Callers that require strict
+        atomicity should handle cleanup themselves (e.g. via
+        :func:`~spkrepo.api._cleanup_on_failure`).
+
+    .. note::
+        This function calls ``session.flush()`` at the end to push all pending
+        changes to the database within the current transaction. The caller is
+        responsible for committing or rolling back.
+
     :param session: SQLAlchemy session
     :param build: the :class:`~spkrepo.models.Build` to update
     :param spk: a parsed :class:`SPK` instance
@@ -644,8 +656,12 @@ def apply_info_from_spk(session, build, spk, md5_hash):
                 language=language, description=value
             )
 
+    # Icon files are written to disk here. If anything raises after this point
+    # the caller's session rollback will undo the DB changes but the files will
+    # remain on disk — see docstring note above.
     existing_icons = dict(version.icons)
     new_sizes = set(spk.icons.keys()) if spk.icons else set()
+    written_icon_paths = []
     for stale_size in set(existing_icons) - new_sizes:
         del version.icons[stale_size]
 
@@ -654,18 +670,31 @@ def apply_info_from_spk(session, build, spk, md5_hash):
             current_app.config["DATA_PATH"], package.name, str(version.version)
         )
         os.makedirs(version_path, exist_ok=True)
-        for size, icon_stream in spk.icons.items():
-            icon_stream.seek(0)
-            icon_path = os.path.join(
-                package.name, str(version.version), f"icon_{size}.png"
-            )
-            icon = version.icons.get(size)
-            if icon is None:
-                icon = Icon(path=icon_path, size=size)
-                version.icons[size] = icon
-            else:
-                icon.path = icon_path
-            icon.save(icon_stream)
+        try:
+            for size, icon_stream in spk.icons.items():
+                icon_stream.seek(0)
+                icon_path = os.path.join(
+                    package.name, str(version.version), f"icon_{size}.png"
+                )
+                icon = version.icons.get(size)
+                if icon is None:
+                    icon = Icon(path=icon_path, size=size)
+                    version.icons[size] = icon
+                else:
+                    icon.path = icon_path
+                icon.save(icon_stream)
+                written_icon_paths.append(
+                    os.path.join(current_app.config["DATA_PATH"], icon_path)
+                )
+        except Exception:
+            # Clean up any icon files written in this call before re-raising,
+            # so a failed resync does not leave orphaned files on disk.
+            for path in written_icon_paths:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+            raise
 
     # -- Build-level fields --------------------------------------------------
 

--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -4,6 +4,7 @@ import binascii
 import hashlib
 import io
 import json
+import os
 import re
 import tarfile
 import time
@@ -11,10 +12,21 @@ from configparser import ConfigParser
 
 import gnupg
 import requests
+from flask import current_app
 
 from .exceptions import SPKParseError, SPKSignError
 from .ext import db
-from .models import Architecture, Firmware, Language, Role, Service
+from .models import (
+    Architecture,
+    BuildManifest,
+    Description,
+    DisplayName,
+    Firmware,
+    Icon,
+    Language,
+    Role,
+    Service,
+)
 
 #: Regex for a firmware string e.g. "6.2-23739"
 firmware_re = re.compile(r"^(?P<version>\d+\.\d)-(?P<build>\d{3,6})$")
@@ -351,6 +363,341 @@ class SPK(object):
 
         response.encoding = "ascii"
         return response.text
+
+
+# ---------------------------------------------------------------------------
+# Shared SPK processing helpers
+# ---------------------------------------------------------------------------
+
+
+def resolve_firmware(session, value, allow_none=False):
+    """Resolve a firmware string like '6.2-23739' to a
+    :class:`~spkrepo.models.Firmware`.
+
+    :param session: SQLAlchemy session
+    :param value: firmware string from SPK INFO
+    :param allow_none: if True, a missing/empty value returns None instead of raising
+    :raises ValueError: if the value is missing (and allow_none is False), malformed,
+                        or not found in the database
+    """
+    if not value:
+        if allow_none:
+            return None
+        raise ValueError("Missing firmware information in INFO")
+
+    match = firmware_re.match(value)
+    if not match:
+        raise ValueError(f"Invalid firmware value: {value}")
+
+    firmware = Firmware.find(int(match.group("build")))
+    if firmware is None:
+        raise ValueError(f"Unknown firmware: {value}")
+
+    return session.merge(firmware, load=False)
+
+
+def resolve_architectures(session, arch_string):
+    """Resolve a space-separated architecture string from SPK INFO to a list of
+    :class:`~spkrepo.models.Architecture` instances.
+
+    :param session: SQLAlchemy session
+    :param arch_string: space-separated arch string e.g. "88f628x x86_64"
+    :raises ValueError: if arch_string is missing or any architecture is unknown
+    """
+    if not arch_string:
+        raise ValueError("Missing 'arch' field in INFO")
+    architectures = []
+    for info_arch in arch_string.split():
+        architecture = Architecture.find(info_arch, syno=True)
+        if architecture is None:
+            raise ValueError(f"Unknown architecture: {info_arch}")
+        architectures.append(session.merge(architecture, load=False))
+    return architectures
+
+
+def resolve_services(service_string):
+    """Resolve a space-separated service dependency string from SPK INFO to a list of
+    :class:`~spkrepo.models.Service` instances.
+
+    :param service_string: space-separated service codes e.g. "apache-web mysql",
+                           or None/empty for no dependencies
+    :raises ValueError: if any service code is not found in the database
+    """
+    if not service_string:
+        return []
+    services = []
+    for service_code in service_string.split():
+        service = Service.find(service_code)
+        if service is None:
+            raise ValueError(f"Unknown dependent service: {service_code}")
+        services.append(service)
+    return services
+
+
+def extract_version_metadata(spk):
+    """Extract all version-level fields from an SPK into a plain dict without
+    touching the database. Used to compare builds of the same version for
+    consistency before writing anything.
+
+    :param spk: a parsed :class:`SPK` instance
+    :returns: dict of version-level field values
+    """
+    info = spk.info
+    version_match = version_re.match(info.get("version", ""))
+    startable = True
+    if info.get("startable") is False or info.get("ctl_stop") is False:
+        startable = False
+    # Normalise displaynames to language-code keys (matching DB storage):
+    # INFO key "displayname" -> "enu", "displayname_fre" -> "fre", etc.
+    # Note: create_info also emits "displayname_enu" alongside "displayname",
+    # so we process suffixed keys first, then let the bare key set "enu" last,
+    # ensuring an override of info["displayname"] is not shadowed by
+    # info["displayname_enu"] still holding the original value.
+    displaynames = {}
+    for k, v in info.items():
+        if k.startswith("displayname_"):
+            displaynames[k.split("_", 1)[1]] = v
+    if "displayname" in info:
+        displaynames["enu"] = info["displayname"]
+
+    # Same normalisation for descriptions.
+    descriptions = {}
+    for k, v in info.items():
+        if k.startswith("description_"):
+            descriptions[k.split("_", 1)[1]] = v
+    if "description" in info:
+        descriptions["enu"] = info["description"]
+
+    return {
+        "upstream_version": (
+            version_match.group("upstream_version") if version_match else None
+        ),
+        "changelog": info.get("changelog"),
+        "report_url": info.get("report_url"),
+        "distributor": info.get("distributor"),
+        "distributor_url": info.get("distributor_url"),
+        "maintainer": info.get("maintainer"),
+        "maintainer_url": info.get("maintainer_url"),
+        "install_wizard": "install" in spk.wizards,
+        "upgrade_wizard": "upgrade" in spk.wizards,
+        "startable": startable,
+        "license": spk.license,
+        "install_dep_services": (
+            set(info["install_dep_services"].split())
+            if info.get("install_dep_services")
+            else set()
+        ),
+        "displaynames": displaynames,
+        "descriptions": descriptions,
+    }
+
+
+def assert_version_metadata_matches_db(version, spk):
+    """Raise :exc:`ValueError` if the SPK's version-level metadata conflicts with
+    what is already stored on an existing :class:`~spkrepo.models.Version` record.
+
+    Call this before writing anything when uploading a new build to an existing
+    version, to ensure all builds within a version carry consistent metadata.
+
+    :param version: the existing :class:`~spkrepo.models.Version` DB record
+    :param spk: a parsed :class:`SPK` instance for the incoming build
+    :raises ValueError: listing all mismatched fields if any inconsistency is found
+    """
+    incoming = extract_version_metadata(spk)
+    mismatches = []
+
+    simple_fields = (
+        "upstream_version",
+        "changelog",
+        "report_url",
+        "distributor",
+        "distributor_url",
+        "maintainer",
+        "maintainer_url",
+        "install_wizard",
+        "upgrade_wizard",
+        "startable",
+        "license",
+    )
+    for field in simple_fields:
+        spk_val = incoming[field]
+        db_val = getattr(version, field)
+        # startable=None in the DB means "default true", same as SPK omitting the key
+        if field == "startable" and db_val is None:
+            db_val = True
+        if spk_val != db_val:
+            mismatches.append(f"{field}: SPK has {spk_val!r}, DB has {db_val!r}")
+
+    existing_services = {s.code for s in version.service_dependencies}
+    if incoming["install_dep_services"] != existing_services:
+        mismatches.append(
+            f"service_dependencies: SPK has {incoming['install_dep_services']}, "
+            f"DB has {existing_services}"
+        )
+
+    existing_displaynames = {k: v.displayname for k, v in version.displaynames.items()}
+    if incoming["displaynames"] != existing_displaynames:
+        mismatches.append(
+            f"displaynames: SPK has {incoming['displaynames']}, "
+            f"DB has {existing_displaynames}"
+        )
+
+    existing_descriptions = {k: v.description for k, v in version.descriptions.items()}
+    if incoming["descriptions"] != existing_descriptions:
+        mismatches.append(
+            f"descriptions: SPK has {incoming['descriptions']}, "
+            f"DB has {existing_descriptions}"
+        )
+
+    if mismatches:
+        raise ValueError(
+            "SPK version-level metadata conflicts with existing builds:\n"
+            + "\n".join(f"  - {m}" for m in mismatches)
+        )
+
+
+def apply_info_from_spk(session, build, spk, md5_hash):
+    """Apply all metadata from a parsed SPK onto the given build and its parent
+    version. This is the single source of truth for writing SPK metadata to the
+    database, used by both the upload path (api.py) and the resync path (admin.py).
+
+    Version-level fields (shared across all builds of a version) are written
+    unconditionally — callers must ensure consistency has already been checked
+    via :func:`assert_version_metadata_matches_db` before calling this.
+
+    :param session: SQLAlchemy session
+    :param build: the :class:`~spkrepo.models.Build` to update
+    :param spk: a parsed :class:`SPK` instance
+    :param md5_hash: pre-calculated MD5 hex string of the SPK file
+    :raises ValueError: on any validation failure (package mismatch, bad version, etc.)
+    """
+    info = spk.info
+    package = build.version.package
+
+    if info.get("package") != package.name:
+        raise ValueError("INFO package does not match build package")
+
+    version_match = version_re.match(info.get("version", ""))
+    if not version_match:
+        raise ValueError("Invalid INFO version value")
+
+    version_number = int(version_match.group("version"))
+    if version_number != build.version.version:
+        raise ValueError("INFO version does not match build version")
+
+    # -- Version-level fields ------------------------------------------------
+
+    version = build.version
+    version.upstream_version = version_match.group("upstream_version")
+    version.changelog = info.get("changelog")
+    version.report_url = info.get("report_url")
+    version.distributor = info.get("distributor")
+    version.distributor_url = info.get("distributor_url")
+    version.maintainer = info.get("maintainer")
+    version.maintainer_url = info.get("maintainer_url")
+    version.install_wizard = "install" in spk.wizards
+    version.upgrade_wizard = "upgrade" in spk.wizards
+
+    startable = True  # default per Synology docs
+    if info.get("startable") is False or info.get("ctl_stop") is False:
+        startable = False
+    version.startable = startable
+
+    version.license = spk.license
+    version.service_dependencies = resolve_services(info.get("install_dep_services"))
+
+    version.displaynames.clear()
+    default_display = info.get("displayname")
+    if default_display:
+        language = Language.find("enu")
+        if language is None:
+            raise ValueError("Language 'enu' is not defined")
+        version.displaynames[language.code] = DisplayName(
+            language=language, displayname=default_display
+        )
+    for key, value in info.items():
+        if key.startswith("displayname_"):
+            language_code = key.split("_", 1)[1]
+            language = Language.find(language_code)
+            if language is None:
+                raise ValueError(f"Unknown INFO displayname language: {language_code}")
+            version.displaynames[language.code] = DisplayName(
+                language=language, displayname=value
+            )
+
+    version.descriptions.clear()
+    default_description = info.get("description")
+    if default_description:
+        language = Language.find("enu")
+        if language is None:
+            raise ValueError("Language 'enu' is not defined")
+        version.descriptions[language.code] = Description(
+            language=language, description=default_description
+        )
+    for key, value in info.items():
+        if key.startswith("description_"):
+            language_code = key.split("_", 1)[1]
+            language = Language.find(language_code)
+            if language is None:
+                raise ValueError(f"Unknown INFO description language: {language_code}")
+            version.descriptions[language.code] = Description(
+                language=language, description=value
+            )
+
+    existing_icons = dict(version.icons)
+    new_sizes = set(spk.icons.keys()) if spk.icons else set()
+    for stale_size in set(existing_icons) - new_sizes:
+        del version.icons[stale_size]
+
+    if spk.icons:
+        version_path = os.path.join(
+            current_app.config["DATA_PATH"], package.name, str(version.version)
+        )
+        os.makedirs(version_path, exist_ok=True)
+        for size, icon_stream in spk.icons.items():
+            icon_stream.seek(0)
+            icon_path = os.path.join(
+                package.name, str(version.version), f"icon_{size}.png"
+            )
+            icon = version.icons.get(size)
+            if icon is None:
+                icon = Icon(path=icon_path, size=size)
+                version.icons[size] = icon
+            else:
+                icon.path = icon_path
+            icon.save(icon_stream)
+
+    # -- Build-level fields --------------------------------------------------
+
+    build.architectures = resolve_architectures(session, info.get("arch"))
+    build.firmware_min = resolve_firmware(
+        session, info.get("firmware") or info.get("os_min_ver")
+    )
+
+    firmware_max_value = info.get("os_max_ver")
+    firmware_max = resolve_firmware(session, firmware_max_value, allow_none=True)
+    if firmware_max and firmware_max.build < build.firmware_min.build:
+        raise ValueError(
+            "Maximum firmware must be greater than or equal to minimum firmware"
+        )
+    build.firmware_max = firmware_max
+
+    build.checksum = info.get("checksum")
+    build.md5 = md5_hash
+
+    manifest = build.buildmanifest
+    if manifest is None:
+        manifest = BuildManifest()
+        build.buildmanifest = manifest
+
+    manifest.dependencies = info.get("install_dep_packages")
+    manifest.conf_dependencies = spk.conf_dependencies
+    manifest.conflicts = info.get("install_conflict_packages")
+    manifest.conf_conflicts = spk.conf_conflicts
+    manifest.conf_privilege = spk.conf_privilege
+    manifest.conf_resource = spk.conf_resource
+
+    session.flush()
 
 
 def populate_db():

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -274,9 +274,11 @@ class SignResyncMixin:
                 _resync_build_metadata(db.session, build)
                 db.session.commit()
                 successes.append(label)
-            except Exception as exc:  # pragma: no cover
+            except Exception as exc:
                 db.session.rollback()
                 failures.append((label, str(exc)))
+        if successes:
+            cache.delete("packages_versions")
         _flash_action_results(successes, failures, item_label="build")
 
     @action(
@@ -294,6 +296,8 @@ class SignResyncMixin:
             except Exception as exc:
                 db.session.rollback()
                 failures.append((label, str(exc)))
+        if successes:
+            cache.delete("packages_versions")
         _flash_action_results(successes, failures, item_label="build")
 
 
@@ -879,9 +883,6 @@ class BuildView(SignResyncMixin, ModelView):
             f"{m.size / 1024 / 1024:.1f} MB" if m.size else None
         ),
         "active": _bool_formatter,
-    }
-    column_formatters_detail = {
-        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
     }
     column_formatters_detail = {
         "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -21,20 +21,19 @@ from ..ext import cache, db
 from ..models import (
     Architecture,
     Build,
-    BuildManifest,
-    Description,
-    DisplayName,
     DownloadStat,
     Firmware,
-    Icon,
-    Language,
     Package,
     Screenshot,
     Service,
     User,
     Version,
 )
-from ..utils import SPK, firmware_re, version_re
+from ..utils import (
+    SPK,
+    apply_info_from_spk,
+    extract_version_metadata,
+)
 
 # ---------------------------------------------------------------------------
 # Shared formatters
@@ -74,171 +73,6 @@ def _flash_action_results(successes, failures, skipped=None, item_label="item"):
 # ---------------------------------------------------------------------------
 
 
-def _resolve_firmware(session, value, allow_none=False):
-    if not value:
-        if allow_none:
-            return None
-        raise ValueError("Missing firmware information in INFO")
-
-    match = firmware_re.match(value)
-    if not match:
-        raise ValueError(f"Invalid firmware value: {value}")
-
-    firmware = Firmware.find(int(match.group("build")))
-    if firmware is None:
-        raise ValueError(f"Unknown firmware: {value}")
-
-    return session.merge(firmware, load=False)
-
-
-def _apply_info_from_spk(session, build, spk, md5_hash):
-    info = spk.info
-    package = build.version.package
-
-    if info.get("package") != package.name:
-        raise ValueError("INFO package does not match build package")
-
-    version_match = version_re.match(info.get("version", ""))
-    if not version_match:
-        raise ValueError("Invalid INFO version value")
-
-    version_number = int(version_match.group("version"))
-    if version_number != build.version.version:
-        raise ValueError("INFO version does not match build version")
-
-    version = build.version
-    version.upstream_version = version_match.group("upstream_version")
-    version.changelog = info.get("changelog")
-    version.report_url = info.get("report_url")
-    version.distributor = info.get("distributor")
-    version.distributor_url = info.get("distributor_url")
-    version.maintainer = info.get("maintainer")
-    version.maintainer_url = info.get("maintainer_url")
-    version.install_wizard = "install" in spk.wizards
-    version.upgrade_wizard = "upgrade" in spk.wizards
-
-    startable = True  # default per Synology docs
-    if info.get("startable") is False or info.get("ctl_stop") is False:
-        startable = False
-    version.startable = startable
-
-    version.license = spk.license
-
-    install_services = info.get("install_dep_services")
-    services = []
-    if install_services:
-        for service_code in install_services.split():
-            service = Service.find(service_code)
-            if service is None:
-                raise ValueError(f"Unknown dependent service: {service_code}")
-            services.append(service)
-    version.service_dependencies = services
-
-    version.displaynames.clear()
-    default_display = info.get("displayname")
-    if default_display:
-        language = Language.find("enu")
-        if language is None:
-            raise ValueError("Language 'enu' is not defined")
-        version.displaynames[language.code] = DisplayName(
-            language=language, displayname=default_display
-        )
-
-    for key, value in info.items():
-        if key.startswith("displayname_"):
-            language_code = key.split("_", 1)[1]
-            language = Language.find(language_code)
-            if language is None:
-                raise ValueError(f"Unknown INFO displayname language: {language_code}")
-            version.displaynames[language.code] = DisplayName(
-                language=language, displayname=value
-            )
-
-    version.descriptions.clear()
-    default_description = info.get("description")
-    if default_description:
-        language = Language.find("enu")
-        if language is None:
-            raise ValueError("Language 'enu' is not defined")
-        version.descriptions[language.code] = Description(
-            language=language, description=default_description
-        )
-
-    for key, value in info.items():
-        if key.startswith("description_"):
-            language_code = key.split("_", 1)[1]
-            language = Language.find(language_code)
-            if language is None:
-                raise ValueError(f"Unknown INFO description language: {language_code}")
-            version.descriptions[language.code] = Description(
-                language=language, description=value
-            )
-
-    existing_icons = dict(version.icons)
-    new_sizes = set(spk.icons.keys()) if spk.icons else set()
-    for stale_size in set(existing_icons) - new_sizes:
-        del version.icons[stale_size]
-
-    if spk.icons:
-        version_path = os.path.join(
-            current_app.config["DATA_PATH"], package.name, str(version.version)
-        )
-        os.makedirs(version_path, exist_ok=True)
-        for size, icon_stream in spk.icons.items():
-            icon_stream.seek(0)
-            icon_path = os.path.join(
-                package.name, str(version.version), f"icon_{size}.png"
-            )
-            icon = version.icons.get(size)
-            if icon is None:
-                icon = Icon(path=icon_path, size=size)
-                version.icons[size] = icon
-            else:
-                icon.path = icon_path
-            icon.save(icon_stream)
-
-    arch_value = info.get("arch")
-    if not arch_value:
-        raise ValueError("Missing 'arch' field in INFO")
-    architectures = []
-    for info_arch in arch_value.split():
-        architecture = Architecture.find(info_arch, syno=True)
-        if architecture is None:
-            raise ValueError(f"Unknown architecture: {info_arch}")
-        architectures.append(session.merge(architecture, load=False))
-    build.architectures = architectures
-
-    firmware = _resolve_firmware(
-        session, info.get("firmware") or info.get("os_min_ver")
-    )
-    build.firmware_min = firmware
-
-    firmware_max_value = info.get("os_max_ver")
-    firmware_max = _resolve_firmware(session, firmware_max_value, allow_none=True)
-    if firmware_max and firmware_max.build < firmware.build:
-        raise ValueError(
-            "Maximum firmware must be greater than or equal to minimum firmware"
-        )
-    build.firmware_max = firmware_max
-
-    build.checksum = info.get("checksum")
-    build.md5 = md5_hash
-
-    manifest = build.buildmanifest
-    if manifest is None:
-        manifest = BuildManifest()
-        build.buildmanifest = manifest
-
-    manifest.dependencies = info.get("install_dep_packages")
-    manifest.conf_dependencies = spk.conf_dependencies
-    manifest.conflicts = info.get("install_conflict_packages")
-    manifest.conf_conflicts = spk.conf_conflicts
-    manifest.conf_privilege = spk.conf_privilege
-    manifest.conf_resource = spk.conf_resource
-
-    session.flush()
-
-
 def _resync_build_file(build):
     """Recalculate md5 and size from the build file on disk."""
     if not build.path:
@@ -248,14 +82,36 @@ def _resync_build_file(build):
 
 
 def _resync_build_metadata(session, build):
+    """Re-read the SPK file for a build, check it is consistent with all sibling
+    builds under the same version, then apply the metadata to the database.
+
+    Raises ValueError if the build's SPK metadata conflicts with any sibling SPK,
+    preventing last-write-wins corruption of shared version-level fields.
+    """
     if not build.path:
         raise ValueError("Build has no file path")
 
     file_path = os.path.join(current_app.config["DATA_PATH"], build.path)
     with io.open(file_path, "rb") as stream:
         spk = SPK(stream)
+        incoming_meta = extract_version_metadata(spk)
+
+        for sibling in build.version.builds:
+            if sibling.id == build.id or not sibling.path:
+                continue
+            sibling_path = os.path.join(current_app.config["DATA_PATH"], sibling.path)
+            with io.open(sibling_path, "rb") as s2:
+                sibling_meta = extract_version_metadata(SPK(s2))
+            if sibling_meta != incoming_meta:
+                raise ValueError(
+                    f"Version-level metadata mismatch between "
+                    f"{os.path.basename(build.path)} and "
+                    f"{os.path.basename(sibling.path)} — resync aborted. "
+                    f"Inspect the SPK files to resolve the inconsistency."
+                )
+
         md5 = spk.calculate_md5()
-        _apply_info_from_spk(session, build, spk, md5)
+        apply_info_from_spk(session, build, spk, md5)
 
 
 # ---------------------------------------------------------------------------
@@ -1026,6 +882,12 @@ class BuildView(SignResyncMixin, ModelView):
     }
     column_formatters_detail = {
         "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
+    }
+    column_formatters_detail = {
+        "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
+        "size": lambda v, c, m, p: (
+            f"{m.size / 1024 / 1024:.1f} MB" if m.size else None
+        ),
     }
     column_default_sort = (Build.insert_date, True)
 

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -29,11 +29,7 @@ from ..models import (
     User,
     Version,
 )
-from ..utils import (
-    SPK,
-    apply_info_from_spk,
-    extract_version_metadata,
-)
+from ..utils import SPK, apply_info_from_spk, extract_version_metadata
 
 # ---------------------------------------------------------------------------
 # Shared formatters

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -161,9 +161,9 @@ class Packages(Resource):
                     ),
                 )
 
-        # Services — validate only here; version object takes ownership on creation
+        # Services — resolve once here; reused in version creation below
         try:
-            resolve_services(spk.info.get("install_dep_services"))
+            services = resolve_services(spk.info.get("install_dep_services"))
         except ValueError as e:
             abort(422, message=str(e))
 
@@ -223,10 +223,7 @@ class Packages(Resource):
 
             for key, value in spk.info.items():
                 if key == "install_dep_services":
-                    for service_name in value.split():
-                        version.service_dependencies.append(
-                            resolve_services(service_name)[0]
-                        )
+                    version.service_dependencies = services
                 elif key == "displayname":
                     version.displaynames["enu"] = DisplayName(
                         language=Language.find("enu"), displayname=value

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -14,20 +14,24 @@ from flask_security import current_user
 from ..exceptions import SPKParseError, SPKSignError
 from ..ext import db
 from ..models import (
-    Architecture,
     Build,
     BuildManifest,
     Description,
     DisplayName,
-    Firmware,
     Icon,
     Language,
     Package,
-    Service,
     Version,
     user_datastore,
 )
-from ..utils import SPK, firmware_re, version_re
+from ..utils import (
+    SPK,
+    assert_version_metadata_matches_db,
+    resolve_architectures,
+    resolve_firmware,
+    resolve_services,
+    version_re,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -128,31 +132,26 @@ class Packages(Resource):
             abort(422, message="Package contains a signature")
 
         # Architectures
-        architectures = []
-        for info_arch in spk.info["arch"].split():
-            architecture = Architecture.find(info_arch, syno=True)
-            if architecture is None:
-                abort(422, message=f"Unknown architecture: {info_arch}")
-            architectures.append(architecture)
+        try:
+            architectures = resolve_architectures(db.session, spk.info.get("arch"))
+        except ValueError as e:
+            abort(422, message=str(e))
 
-        # Firmware
+        # Firmware min
         input_firmware = spk.info.get("firmware") or spk.info.get("os_min_ver")
-        match = firmware_re.match(input_firmware)
-        if not match:
-            abort(422, message="Invalid firmware")
-        firmware = Firmware.find(int(match.group("build")))
-        if firmware is None:
-            abort(422, message="Unknown firmware")
+        try:
+            firmware = resolve_firmware(db.session, input_firmware)
+        except ValueError as e:
+            abort(422, message=str(e))
 
+        # Firmware max
         firmware_max = None
         input_firmware_max = spk.info.get("os_max_ver")
         if input_firmware_max:
-            max_match = firmware_re.match(input_firmware_max)
-            if not max_match:
-                abort(422, message="Invalid maximum firmware")
-            firmware_max = Firmware.find(int(max_match.group("build")))
-            if firmware_max is None:
-                abort(422, message="Unknown maximum firmware")
+            try:
+                firmware_max = resolve_firmware(db.session, input_firmware_max)
+            except ValueError as e:
+                abort(422, message=str(e))
             if firmware_max.build < firmware.build:
                 abort(
                     422,
@@ -162,13 +161,11 @@ class Packages(Resource):
                     ),
                 )
 
-        # Services
-        input_install_dep_services = spk.info.get("install_dep_services", None)
-        if input_install_dep_services:
-            for info_dep_service in input_install_dep_services.split():
-                service_name = Service.find(info_dep_service)
-                if service_name is None:
-                    abort(422, message=f"Unknown dependent service: {info_dep_service}")
+        # Services — validate only here; version object takes ownership on creation
+        try:
+            resolve_services(spk.info.get("install_dep_services"))
+        except ValueError as e:
+            abort(422, message=str(e))
 
         # Package
         create_package = False
@@ -189,20 +186,21 @@ class Packages(Resource):
         match = version_re.match(spk.info["version"])
         if not match:
             abort(422, message="Invalid version")
+
         version = {v.version: v for v in package.versions}.get(
             int(match.group("version"))
         )
-        if version is not None and version.upstream_version != match.group(
-            "upstream_version"
-        ):
-            abort(
-                422,
-                message=(
-                    f"Upstream version mismatch: expected {version.upstream_version}, "
-                    f"got {match.group('upstream_version')}"
-                ),
-            )
-        if version is None:
+
+        if version is not None:
+            # Existing version — enforce full metadata consistency before proceeding.
+            # This catches cases where a build pipeline bug produces SPKs with
+            # differing version-level metadata (e.g. different SPK_VER) for builds
+            # that are part of the same logical release.
+            try:
+                assert_version_metadata_matches_db(version, spk)
+            except ValueError as e:
+                abort(422, message=str(e))
+        else:
             create_version = True
             version_startable = True
             if spk.info.get("startable") is False or spk.info.get("ctl_stop") is False:
@@ -226,7 +224,9 @@ class Packages(Resource):
             for key, value in spk.info.items():
                 if key == "install_dep_services":
                     for service_name in value.split():
-                        version.service_dependencies.append(Service.find(service_name))
+                        version.service_dependencies.append(
+                            resolve_services(service_name)[0]
+                        )
                 elif key == "displayname":
                     version.displaynames["enu"] = DisplayName(
                         language=Language.find("enu"), displayname=value


### PR DESCRIPTION
## Description

Detect and reject inconsistent build metadata at upload and resync time, consolidate duplicated SPK processing logic into shared utilities, and fix cache invalidation, icon cleanup, and service resolution bugs.

### Problem

When a build pipeline bug causes SPKs within the same release to be packaged with different `SPK_VER` values, each SPK can carry subtly different version-level metadata (displaynames, descriptions, changelog, URLs, etc.). Because all builds of a version share a single `Version` row in the database, whichever build is processed last wins — both at upload time and during admin resync. This results in the catalog silently showing a different version than previously, with no indication that anything went wrong.

### Root cause

`_apply_info_from_spk` in `admin.py` unconditionally overwrites all shared version-level fields on every build it processes. At upload time, `api.py` only validated `upstream_version` against the existing `Version` record, leaving all other fields unchecked. There was no mechanism to detect or reject inconsistent metadata across builds of the same version.

### Changes

#### `utils.py`
- Added `resolve_firmware`, `resolve_architectures`, and `resolve_services` — shared resolution helpers previously duplicated between `api.py` and `admin.py`.
- Added `extract_version_metadata` — extracts all version-level fields from a parsed SPK into a plain dict without touching the database. Handles the `displayname`/`displayname_enu` key normalisation so comparisons are always in language-code form matching DB storage.
- Added `assert_version_metadata_matches_db` — compares an incoming SPK's version-level metadata against an existing `Version` record and raises `ValueError` listing every mismatched field. Normalises `startable=None` in the DB to `True` to match the SPK default.
- Moved `apply_info_from_spk` from `admin.py` into `utils.py` as the single source of truth for writing SPK metadata to the database, used by both the upload and resync paths.
- `apply_info_from_spk` now cleans up any icon files written during a failed call before re-raising, preventing orphaned files on disk when a resync fails mid-write. The docstring explicitly notes the remaining limitation (icons written before a caller-initiated rollback are handled by `_cleanup_on_failure` in the upload path) and documents the `session.flush()` side effect.

#### `api.py`
- Replaced the partial `upstream_version`-only consistency check with a call to `assert_version_metadata_matches_db` covering all version-level fields. Returns HTTP 422 with a field-by-field mismatch description on failure.
- Replaced inline firmware, architecture, and service resolution with calls to the shared utils functions.
- `resolve_services` is now called once and the resolved list reused in the version creation block, eliminating redundant `Service.find` calls that the previous per-service loop was making.

#### `admin.py`
- Removed `_resolve_firmware` and `_apply_info_from_spk`, now imported from `utils.py`.
- `_resync_build_metadata` now reads metadata from all sibling SPK files before writing anything. If any sibling's metadata disagrees with the build being resynced, the operation is aborted with a descriptive error rather than silently overwriting shared version fields.
- `action_resync_info` and `action_resync_file` now invalidate the `packages_versions` cache after any successful resync, consistent with `action_activate` and `action_deactivate`. Previously a resync would not be reflected in the catalog until the cache expired naturally.

#### `test_utils.py`
- Added `ExtractVersionMetadataTestCase` — covers displayname/description key normalisation, `startable` defaulting, services as a set, and wizard flags.
- Added `AssertVersionMetadataMatchesDBTestCase` — covers clean match, individual field mismatches, and multi-field error reporting.

### `test_api.py`
- Updated existing upstream version mismatch test to assert against the new error message format.
- Added tests for displayname mismatch rejection, changelog mismatch rejection, and DB immutability on rejected upload.

### `test_admin.py`
- Added sibling SPK consistency tests to both `VersionTestCase` and `BuildTestCase` — verifies that resync fails with a flash error rather than succeeding when sibling builds on disk carry conflicting version-level metadata.
- Added `test_action_resync_info_single_build_no_siblings_succeeds` to both `VersionTestCase` and `BuildTestCase` — verifies a build with no siblings resyncs cleanly without the sibling comparison path interfering.
- Added `test_action_resync_info_invalidates_cache` and `test_action_resync_file_invalidates_cache` to both `VersionTestCase` and `BuildTestCase` — primes the cache with a stale sentinel, triggers the action, and asserts the key is cleared.