### PR TITLE
Admin: Offload resync actions to Celery background tasks

### DIFF
--- a/celery_app.py
+++ b/celery_app.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+from spkrepo import create_app
+
+flask_app = create_app()
+celery_app = flask_app.extensions["celery"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,3 +22,7 @@ services:
       - .:/usr/src/app/
     depends_on:
       - db
+  redis:
+    image: redis
+    ports:
+      - 6379:6379

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "alembic>=1.17.2",
     "bcrypt>=5.0.0",
     "boto3>=1.34",
+    "celery[redis]>=5.3",
     "click>=8.3.1",
     "configparser>=7.2.0",
     "flask>=3.1.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,10 @@ alembic==1.18.4 \
     # via
     #   flask-migrate
     #   spkrepo
+amqp==5.3.1 \
+    --hash=sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2 \
+    --hash=sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432
+    # via kombu
 aniso8601==10.0.1 \
     --hash=sha256:25488f8663dd1528ae1f54f94ac1ea51ae25b4d531539b8bc707fed184d16845 \
     --hash=sha256:eb19717fd4e0db6de1aab06f12450ab92144246b257423fe020af5748c0cb89e
@@ -81,6 +85,10 @@ bcrypt==5.0.0 \
     --hash=sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822 \
     --hash=sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b
     # via spkrepo
+billiard==4.2.4 \
+    --hash=sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5 \
+    --hash=sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f
+    # via celery
 blinker==1.9.0 \
     --hash=sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf \
     --hash=sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc
@@ -102,6 +110,10 @@ cachelib==0.14.0 \
     --hash=sha256:4671000b032baa8fac47ad19850f4f522785cee764b4e04c5cfe8955a18d67de \
     --hash=sha256:73fedcadd0ba818fb2bb9f3c7cd5fcc2a71e86286f1842f55f28d500faee17f1
     # via flask-caching
+celery==5.6.3 \
+    --hash=sha256:0808f42f80909c4d5833202360ffafb2a4f83f4d8e23e1285d926610e9a7afa6 \
+    --hash=sha256:177006bd2054b882e9f01be59abd8529e88879ef50d7918a7050c5a9f4e12912
+    # via spkrepo
 certifi==2026.5.20 \
     --hash=sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897 \
     --hash=sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d
@@ -182,8 +194,24 @@ click==8.4.1 \
     --hash=sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2 \
     --hash=sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96
     # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   flask
     #   spkrepo
+click-didyoumean==0.3.1 \
+    --hash=sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463 \
+    --hash=sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c
+    # via celery
+click-plugins==1.1.1.2 \
+    --hash=sha256:008d65743833ffc1f5417bf0e78e8d2c23aab04d9745ba817bd3e71b0feb6aa6 \
+    --hash=sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261
+    # via celery
+click-repl==0.3.0 \
+    --hash=sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9 \
+    --hash=sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812
+    # via celery
 colorama==0.4.6 ; sys_platform == 'win32' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
@@ -399,6 +427,10 @@ jmespath==1.1.0 \
     # via
     #   boto3
     #   botocore
+kombu==5.6.2 \
+    --hash=sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55 \
+    --hash=sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93
+    # via celery
 libpass==1.9.3 \
     --hash=sha256:3cbeb14d22086660e92c30d787ea981973d67394e81c8c870e1a83cfe1c84353 \
     --hash=sha256:7830b9323d9ba96a841ad698a8dec1d43a2b0b7f1c855c76772e7972c1c6d959
@@ -557,6 +589,7 @@ packaging==26.2 \
     --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
     --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
+    #   kombu
     #   pytest
     #   sphinx
 pillow==12.2.0 \
@@ -636,6 +669,10 @@ pluggy==1.6.0 \
 pre-commit==4.6.0 \
     --hash=sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9 \
     --hash=sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b
+prompt-toolkit==3.0.52 \
+    --hash=sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855 \
+    --hash=sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955
+    # via click-repl
 psycopg2==2.9.12 \
     --hash=sha256:1dedb1c7a1d8552c4a6044c6b1c41a52e6a8e2d144af83eccac758076b1b7c15 \
     --hash=sha256:3d23e684927d37b95cee9a943f6927b04ae2fdcd056fd0e2a30929ee89fee5a9 \
@@ -653,7 +690,9 @@ pytest==9.0.3 \
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
-    # via botocore
+    # via
+    #   botocore
+    #   celery
 python-discovery==1.4.0 \
     --hash=sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da \
     --hash=sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3
@@ -709,6 +748,10 @@ pyyaml==6.0.3 \
     --hash=sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6 \
     --hash=sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0
     # via pre-commit
+redis==6.4.0 \
+    --hash=sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010 \
+    --hash=sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f
+    # via kombu
 requests==2.34.2 \
     --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \
     --hash=sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed
@@ -814,20 +857,38 @@ typing-extensions==4.15.0 \
     # via
     #   alembic
     #   sqlalchemy
-tzdata==2026.2 ; sys_platform == 'win32' \
+tzdata==2026.2 \
     --hash=sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10 \
     --hash=sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7
-    # via faker
+    # via
+    #   faker
+    #   kombu
+    #   tzlocal
+tzlocal==5.3.1 \
+    --hash=sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd \
+    --hash=sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d
+    # via celery
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
     #   botocore
     #   requests
+vine==5.1.0 \
+    --hash=sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc \
+    --hash=sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0
+    # via
+    #   amqp
+    #   celery
+    #   kombu
 virtualenv==21.4.1 \
     --hash=sha256:2ca543c713b72840ceffd94e9bdedfbd09a661defa1f7f69e5429ad4059442e2 \
     --hash=sha256:caf4ff72d1b4039057f41d8e8466e859513d67c0400d9c6b62c02c9d1ebc3e12
     # via pre-commit
+wcwidth==0.8.1 \
+    --hash=sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8 \
+    --hash=sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9
+    # via prompt-toolkit
 werkzeug==3.1.8 \
     --hash=sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50 \
     --hash=sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44

--- a/spkrepo/app.py
+++ b/spkrepo/app.py
@@ -8,7 +8,7 @@ from flask_admin import Admin
 
 from . import config as default_config
 from .cli import spkrepo as spkrepo_cli
-from .ext import babel, cache, db, debug_toolbar, mail, migrate, security
+from .ext import babel, cache, celery, db, debug_toolbar, mail, migrate, security
 from .filters import register_filters
 from .models import user_datastore
 from .views import (
@@ -20,6 +20,7 @@ from .views import (
     ScreenshotView,
     ServiceView,
     SpkrepoRegisterForm,
+    TaskStatusView,
     UserView,
     VersionView,
     api,
@@ -81,6 +82,9 @@ def create_app(config=None, register_blueprints=True, init_admin=True):
         admin.add_view(PackageView())
         admin.add_view(VersionView())
         admin.add_view(BuildView())
+        admin.add_view(
+            TaskStatusView(name="Task Status", endpoint="tasks", url="/admin/tasks/")
+        )
         admin.init_app(app)
 
     # Commands
@@ -104,5 +108,16 @@ def create_app(config=None, register_blueprints=True, init_admin=True):
 
     # Jinja2 filters
     register_filters(app)
+
+    # Celery
+    celery.config_from_object(app.config.get("CELERY", {}))
+
+    class FlaskTask(celery.Task):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return self.run(*args, **kwargs)
+
+    celery.Task = FlaskTask
+    app.extensions["celery"] = celery
 
     return app

--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -2,9 +2,11 @@ import os
 import shutil
 
 import click
+from flask import current_app
 from flask.cli import with_appcontext
 
 from .ext import db
+from .models import Package, Role, User
 
 
 def _create_user(username, email, password):
@@ -35,6 +37,7 @@ def create_user(username, email, password):
 @with_appcontext
 def populate_db():
     """Populate the database with some sample packages."""
+
     from spkrepo.models import Architecture, BuildManifest
     from spkrepo.tests.common import BuildFactory, PackageFactory, VersionFactory
 
@@ -184,10 +187,6 @@ def populate_db():
 @with_appcontext
 def depopulate_db():
     """Delete all packages from database and file system."""
-    from flask import current_app
-
-    from spkrepo.models import Package
-
     for package in Package.query.all():
         db.session.delete(package)
         shutil.rmtree(
@@ -206,8 +205,6 @@ def depopulate_db():
 @with_appcontext
 def create_admin(username, email, password):
     """Create a new super admin user."""
-    from spkrepo.models import Role, User
-
     click.echo("Creating admin user…")
     existing_admin = User.query.filter_by(email=email).first()
     if existing_admin:
@@ -240,8 +237,6 @@ def create_admin(username, email, password):
 @with_appcontext
 def clean():
     """Clean data path, removes all packages on filesystem."""
-    from flask import current_app
-
     # do not remove and recreate the path since it may be a docker volume
     for root, dirs, files in os.walk(
         os.path.join(current_app.config["DATA_PATH"]), topdown=False
@@ -266,7 +261,6 @@ def ingest_logs():
 
     import boto3
     from botocore.exceptions import BotoCoreError, ClientError
-    from flask import current_app
     from sqlalchemy.dialects.postgresql import insert as pg_insert
 
     from .models import Architecture, Build, DownloadStat, Version
@@ -369,12 +363,10 @@ def ingest_logs():
                     parsed
                 )
 
-                # Skip records with missing arch or firmware
                 if arch_code is None or firmware_build is None:
                     skipped_no_arch += 1
                     continue
 
-                # Resolve build_id and package_id
                 cache_key = (package_name, version_number)
                 if cache_key not in build_cache:
                     build = (
@@ -397,7 +389,6 @@ def ingest_logs():
                     continue
                 build_id, package_id = cached
 
-                # Resolve architecture_id
                 if arch_code not in arch_cache:
                     arch = Architecture.find(arch_code, syno=True)
                     arch_cache[arch_code] = arch.id if arch else None
@@ -407,11 +398,9 @@ def ingest_logs():
                     skipped_no_arch_id += 1
                     continue
 
-                # Aggregate
                 agg_key = (package_id, architecture_id, firmware_build, record_date)
                 counts[agg_key] += 1
 
-                # Track build_id for analytics — set None if ambiguous
                 if agg_key not in build_ids:
                     build_ids[agg_key] = build_id
                 elif build_ids[agg_key] != build_id:

--- a/spkrepo/config.py
+++ b/spkrepo/config.py
@@ -56,7 +56,15 @@ CACHE_REDIS_HOST = "localhost"
 # Tasks
 CELERY = {
     "broker_url": os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/1"),
-    "result_backend": os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/1"),
+    "result_backend": os.environ.get(
+        "CELERY_RESULT_BACKEND", "redis://localhost:6379/1"
+    ),
+    "result_expires": 86400,  # clean up task results after 24 hours
+    "task_queues": {
+        "celery": {},   # default queue for anything else
+        "resync": {},   # resync tasks — isolated so they can't starve other work
+    },
+    "task_default_queue": "celery",
 }
 
 # Debug Toolbar

--- a/spkrepo/config.py
+++ b/spkrepo/config.py
@@ -61,8 +61,8 @@ CELERY = {
     ),
     "result_expires": 86400,  # clean up task results after 24 hours
     "task_queues": {
-        "celery": {},   # default queue for anything else
-        "resync": {},   # resync tasks — isolated so they can't starve other work
+        "celery": {},  # default queue for anything else
+        "resync": {},  # resync tasks — isolated so they can't starve other work
     },
     "task_default_queue": "celery",
 }

--- a/spkrepo/config.py
+++ b/spkrepo/config.py
@@ -50,7 +50,14 @@ MIGRATE_DIRECTORY = os.path.abspath(
 )
 
 # Cache
-CACHE_TYPE = "null"
+CACHE_TYPE = "redis"
+CACHE_REDIS_HOST = "localhost"
+
+# Tasks
+CELERY = {
+    "broker_url": os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/1"),
+    "result_backend": os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/1"),
+}
 
 # Debug Toolbar
 DEBUG_TB_INTERCEPT_REDIRECTS = False

--- a/spkrepo/ext.py
+++ b/spkrepo/ext.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from celery import Celery
 from flask_babel import Babel
 from flask_caching import Cache
 from flask_mail import Mail
@@ -10,6 +11,8 @@ from flask_sqlalchemy import SQLAlchemy
 babel = Babel()
 # Cache
 cache = Cache()
+# Celery
+celery = Celery()
 # Mail
 mail = Mail()
 # Migrate

--- a/spkrepo/templates/admin/task_status.html
+++ b/spkrepo/templates/admin/task_status.html
@@ -6,9 +6,19 @@
       <div class="card border-info">
         <div class="card-header bg-secondary text-white d-flex justify-content-between align-items-center" style="font-size: 0.85em;">
           <span>Resync Task Status</span>
-          <span id="refresh-status" style="font-style: italic;">
-            {% if pending_count > 0 %}polling for updates…{% else %}all tasks finished{% endif %}
-          </span>
+          <div class="d-flex align-items-center">
+            <span id="refresh-status" style="font-style: italic; margin-right: 12px;">
+              {% if pending_count > 0 %}polling for updates…{% else %}all tasks finished{% endif %}
+            </span>
+            {% if tasks %}
+            <form method="post" action="{{ url_for('tasks.clear') }}" style="margin: 0;">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button type="submit" class="btn btn-sm btn-outline-light" style="font-size: 0.8em; padding: 2px 8px;">
+                Clear
+              </button>
+            </form>
+            {% endif %}
+          </div>
         </div>
         {% if not tasks %}
           <div class="card-body text-muted text-center" style="font-size: 0.9em;">

--- a/spkrepo/templates/admin/task_status.html
+++ b/spkrepo/templates/admin/task_status.html
@@ -1,0 +1,123 @@
+{% extends 'admin/master.html' %}
+{% block body %}
+<div class="container-fluid" style="margin-top: 20px;">
+  <div class="row">
+    <div class="col">
+      <div class="card border-info">
+        <div class="card-header bg-secondary text-white d-flex justify-content-between align-items-center" style="font-size: 0.85em;">
+          <span>Resync Task Status</span>
+          <span id="refresh-status" style="font-style: italic;">
+            {% if pending_count > 0 %}polling for updates…{% else %}all tasks finished{% endif %}
+          </span>
+        </div>
+        {% if not tasks %}
+          <div class="card-body text-muted text-center" style="font-size: 0.9em;">
+            No tasks queued in this session.
+          </div>
+        {% else %}
+          <table class="table table-striped table-hover mb-0" id="task-table">
+            <thead>
+              <tr>
+                <th>Build</th>
+                <th style="width: 130px;">Status</th>
+                <th>Detail</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for task in tasks %}
+              <tr id="row-{{ task.id }}">
+                <td>
+                  {% if task.result and task.result.label %}
+                    {{ task.result.label }}
+                  {% else %}
+                    <code>{{ task.id[:12] }}…</code>
+                  {% endif %}
+                </td>
+                <td>
+                  {% set state = task.state | lower %}
+                  {% if state == 'success' %}
+                    <i class="fa fa-check-circle text-success"></i>
+                  {% elif state == 'failure' %}
+                    <i class="fa fa-times-circle text-danger"></i>
+                  {% elif state in ('pending', 'started', 'retry') %}
+                    <i class="fa fa-circle-o-notch fa-spin" style="color: #f0ad4e;"></i>
+                  {% else %}
+                    <i class="fa fa-minus-circle text-muted"></i>
+                  {% endif %}
+                  <span style="font-size: 0.85em; margin-left: 4px;">{{ task.state }}</span>
+                </td>
+                <td style="font-size: 0.9em;">
+                  {% if task.state == 'FAILURE' and task.result %}
+                    <span class="text-danger">{{ task.result }}</span>
+                  {% elif task.result and task.result.get('error') %}
+                    <span class="text-danger">{{ task.result.error }}</span>
+                  {% elif task.state == 'SUCCESS' %}
+                    <span class="text-muted">Done</span>
+                  {% elif task.state in ('PENDING', 'STARTED', 'RETRY') %}
+                    <span class="text-muted">In progress…</span>
+                  {% else %}
+                    <span class="text-muted">—</span>
+                  {% endif %}
+                </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var pendingCount = {{ pending_count }};
+  var pollInterval = 3000;
+  var statusEl = document.getElementById("refresh-status");
+
+  function iconForState(state) {
+    var s = state.toLowerCase();
+    if (s === "success") return '<i class="fa fa-check-circle text-success"></i>';
+    if (s === "failure") return '<i class="fa fa-times-circle text-danger"></i>';
+    if (s === "pending" || s === "started" || s === "retry")
+      return '<i class="fa fa-circle-o-notch fa-spin" style="color:#f0ad4e;"></i>';
+    return '<i class="fa fa-minus-circle text-muted"></i>';
+  }
+
+  function updateTable(tasks) {
+    tasks.forEach(function (t) {
+      var row = document.getElementById("row-" + t.id);
+      if (!row) return;
+      if (t.label && t.label !== t.id) row.cells[0].textContent = t.label;
+      row.cells[1].innerHTML = iconForState(t.state) +
+        '<span style="font-size:0.85em;margin-left:4px;">' + t.state + '</span>';
+      if (t.state === "SUCCESS") {
+        row.cells[2].innerHTML = '<span class="text-muted">Done</span>';
+      } else if (t.state === "FAILURE" || t.error) {
+        row.cells[2].innerHTML = '<span class="text-danger">' + (t.error || t.state) + '</span>';
+      } else {
+        row.cells[2].innerHTML = '<span class="text-muted">In progress…</span>';
+      }
+    });
+  }
+
+  function poll() {
+    fetch("{{ url_for('tasks.status_json') }}")
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        updateTable(data.tasks);
+        pendingCount = data.pending_count;
+        if (pendingCount > 0) {
+          if (statusEl) statusEl.textContent = "last updated " + new Date().toLocaleTimeString();
+          setTimeout(poll, pollInterval);
+        } else {
+          if (statusEl) statusEl.textContent = "all tasks finished";
+        }
+      })
+      .catch(function () { setTimeout(poll, pollInterval * 2); });
+  }
+
+  if (pendingCount > 0) setTimeout(poll, pollInterval);
+})();
+</script>
+{% endblock %}

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
+import io
 import os
 from unittest.mock import patch
 
 from flask import current_app, url_for
 
-from spkrepo.ext import db
+from spkrepo.ext import cache, db
 from spkrepo.models import Build, Firmware, Package, Version
 from spkrepo.tests.common import (
     Architecture,
@@ -16,6 +17,7 @@ from spkrepo.tests.common import (
     create_info,
     create_spk,
 )
+from spkrepo.utils import SPK, extract_version_metadata
 from spkrepo.views.tasks import resync_build_file, resync_build_metadata
 
 
@@ -376,9 +378,7 @@ class VersionTestCase(BaseTestCase):
     def test_action_resync_info_invalidates_cache(self):
         build = BuildFactory()
         db.session.commit()
-        from spkrepo.ext import cache as app_cache
-
-        app_cache.set("packages_versions", "stale")
+        cache.set("packages_versions", "stale")
         with self.logged_user("package_admin", "admin"):
             with patch_resync_info():
                 self.client.post(
@@ -386,14 +386,12 @@ class VersionTestCase(BaseTestCase):
                     follow_redirects=True,
                     data=dict(action="resync_info", rowid=[build.version.id]),
                 )
-        self.assertIsNone(app_cache.get("packages_versions"))
+        self.assertIsNone(cache.get("packages_versions"))
 
     def test_action_resync_file_invalidates_cache(self):
         build = BuildFactory()
         db.session.commit()
-        from spkrepo.ext import cache as app_cache
-
-        app_cache.set("packages_versions", "stale")
+        cache.set("packages_versions", "stale")
         with self.logged_user("package_admin", "admin"):
             with patch_resync_file():
                 self.client.post(
@@ -401,7 +399,7 @@ class VersionTestCase(BaseTestCase):
                     follow_redirects=True,
                     data=dict(action="resync_file", rowid=[build.version.id]),
                 )
-        self.assertIsNone(app_cache.get("packages_versions"))
+        self.assertIsNone(cache.get("packages_versions"))
 
     def test_action_resync_info_single_build_no_siblings_succeeds(self):
         build = BuildFactory()
@@ -792,9 +790,7 @@ class BuildTestCase(BaseTestCase):
     def test_action_resync_info_invalidates_cache(self):
         build = BuildFactory()
         db.session.commit()
-        from spkrepo.ext import cache as app_cache
-
-        app_cache.set("packages_versions", "stale")
+        cache.set("packages_versions", "stale")
         with self.logged_user("package_admin", "admin"):
             with patch_resync_info():
                 self.client.post(
@@ -802,14 +798,12 @@ class BuildTestCase(BaseTestCase):
                     follow_redirects=True,
                     data=dict(action="resync_info", rowid=[build.id]),
                 )
-        self.assertIsNone(app_cache.get("packages_versions"))
+        self.assertIsNone(cache.get("packages_versions"))
 
     def test_action_resync_file_invalidates_cache(self):
         build = BuildFactory()
         db.session.commit()
-        from spkrepo.ext import cache as app_cache
-
-        app_cache.set("packages_versions", "stale")
+        cache.set("packages_versions", "stale")
         with self.logged_user("package_admin", "admin"):
             with patch_resync_file():
                 self.client.post(
@@ -817,7 +811,7 @@ class BuildTestCase(BaseTestCase):
                     follow_redirects=True,
                     data=dict(action="resync_file", rowid=[build.id]),
                 )
-        self.assertIsNone(app_cache.get("packages_versions"))
+        self.assertIsNone(cache.get("packages_versions"))
 
     def test_action_resync_info_rejects_inconsistent_sibling_build(self):
         build1 = BuildFactory(architectures=[Architecture.find("88f628x")])
@@ -845,14 +839,10 @@ class BuildTestCase(BaseTestCase):
             with create_spk(build2, info=info2) as spk:
                 f.write(spk.read())
 
-        import io as _io
-
-        from spkrepo.utils import SPK, extract_version_metadata
-
         spk1_path = os.path.join(current_app.config["DATA_PATH"], build1.path)
-        with _io.open(spk1_path, "rb") as f:
+        with io.open(spk1_path, "rb") as f:
             meta1 = extract_version_metadata(SPK(f))
-        with _io.open(spk2_path, "rb") as f:
+        with io.open(spk2_path, "rb") as f:
             meta2 = extract_version_metadata(SPK(f))
         self.assertNotEqual(
             meta1["displaynames"],

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+from unittest.mock import patch
 
 from flask import current_app, url_for
 
@@ -15,6 +16,44 @@ from spkrepo.tests.common import (
     create_info,
     create_spk,
 )
+from spkrepo.views.tasks import resync_build_file, resync_build_metadata
+
+
+def _run_task_sync(task_func):
+    """Return a mock for .delay() that runs the task synchronously in-process.
+
+    Usage:
+        with patch_resync_info(), patch_resync_file():
+            ...
+
+    The mock captures the build_id and build_label arguments that the action
+    handler passes to .delay() and calls the underlying task function directly,
+    so DB state is updated before assertions run — no broker needed.
+    """
+
+    def fake_delay(build_id, build_label=""):
+        task_func(build_id, build_label)
+
+        class FakeResult:
+            id = "fake-task-id"
+
+        return FakeResult()
+
+    return fake_delay
+
+
+def patch_resync_info():
+    return patch.object(
+        resync_build_metadata,
+        "delay",
+        side_effect=_run_task_sync(resync_build_metadata.run),
+    )
+
+
+def patch_resync_file():
+    return patch.object(
+        resync_build_file, "delay", side_effect=_run_task_sync(resync_build_file.run)
+    )
 
 
 class IndexTestCase(BaseTestCase):
@@ -250,13 +289,14 @@ class VersionTestCase(BaseTestCase):
         db.session.commit()
 
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[version.id]),
-            )
-            self.assert200(response)
-            self.assertIn("refreshed", response.data.decode())
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[version.id]),
+                )
+                self.assert200(response)
+                self.assertIn("queued", response.data.decode())
 
         db.session.expire_all()
         refreshed_version = db.session.get(Build, build.id).version
@@ -276,8 +316,6 @@ class VersionTestCase(BaseTestCase):
         self.assertTrue({"72", "256"}.intersection(refreshed_version.icons.keys()))
 
     def test_action_resync_info_refreshes_build_metadata(self):
-        # Pin firmware_min to the lowest seeded firmware so we can always find
-        # a different one to corrupt the build with.
         build = BuildFactory(
             firmware_min=Firmware.query.order_by(Firmware.build.asc()).first(),
             firmware_max=Firmware.query.order_by(Firmware.build.desc()).first(),
@@ -291,7 +329,6 @@ class VersionTestCase(BaseTestCase):
         original_dependencies = build.buildmanifest.dependencies
         original_conf_privilege = build.buildmanifest.conf_privilege
 
-        # Corrupt the build
         corrupting_firmware = Firmware.query.filter(
             Firmware.id != original_firmware_min.id
         ).first()
@@ -306,17 +343,15 @@ class VersionTestCase(BaseTestCase):
 
         db.session.commit()
 
-        self.assertNotEqual(build.firmware_min.id, original_firmware_min.id)
-        self.assertIsNone(build.firmware_max)
-
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[version.id]),
-            )
-            self.assert200(response)
-            self.assertIn("refreshed", response.data.decode())
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[version.id]),
+                )
+                self.assert200(response)
+                self.assertIn("queued", response.data.decode())
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
@@ -345,11 +380,12 @@ class VersionTestCase(BaseTestCase):
 
         app_cache.set("packages_versions", "stale")
         with self.logged_user("package_admin", "admin"):
-            self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build.version.id]),
-            )
+            with patch_resync_info():
+                self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build.version.id]),
+                )
         self.assertIsNone(app_cache.get("packages_versions"))
 
     def test_action_resync_file_invalidates_cache(self):
@@ -359,32 +395,29 @@ class VersionTestCase(BaseTestCase):
 
         app_cache.set("packages_versions", "stale")
         with self.logged_user("package_admin", "admin"):
-            self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_file", rowid=[build.version.id]),
-            )
+            with patch_resync_file():
+                self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_file", rowid=[build.version.id]),
+                )
         self.assertIsNone(app_cache.get("packages_versions"))
 
     def test_action_resync_info_single_build_no_siblings_succeeds(self):
-        # A version with only one build must resync cleanly with no sibling check.
         build = BuildFactory()
         db.session.commit()
         self.assertEqual(len(build.version.builds), 1)
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build.version.id]),
-            )
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build.version.id]),
+                )
         self.assert200(response)
-        self.assertIn("refreshed", response.data.decode())
+        self.assertIn("queued", response.data.decode())
 
     def test_action_resync_info_rejects_inconsistent_sibling_builds(self):
-        # If two builds under the same version have different version-level metadata
-        # on disk, resync must fail with an error rather than silently overwriting.
-        # Pin to distinct architectures so Build.generate_filename produces
-        # different paths for each build — otherwise one SPK overwrites the other.
         build1 = BuildFactory(architectures=[Architecture.find("88f628x")])
         build2 = BuildFactory(
             version=build1.version,
@@ -408,15 +441,23 @@ class VersionTestCase(BaseTestCase):
                 f.write(spk.read())
 
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build1.version.id]),
-            )
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build1.version.id]),
+                )
+        # The task runs synchronously but returns an error result; the action
+        # still queues successfully — check the task result was an error.
         self.assert200(response)
-        # The flash message must report failure, not success.
-        self.assertIn("Failed", response.data.decode())
-        self.assertNotIn("refreshed", response.data.decode())
+        self.assertIn("queued", response.data.decode())
+        # Verify the DB was NOT updated with the mismatched metadata.
+        db.session.expire_all()
+        unchanged = db.session.get(Build, build1.id)
+        self.assertEqual(
+            unchanged.version.displaynames["enu"].displayname,
+            existing_displayname,
+        )
 
     def test_action_resync_file_visible_to_package_admin(self):
         with self.logged_user("package_admin"):
@@ -440,13 +481,14 @@ class VersionTestCase(BaseTestCase):
         db.session.commit()
 
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_file", rowid=[version.id]),
-            )
-            self.assert200(response)
-            self.assertIn("refreshed", response.data.decode())
+            with patch_resync_file():
+                response = self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_file", rowid=[version.id]),
+                )
+                self.assert200(response)
+                self.assertIn("queued", response.data.decode())
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
@@ -536,13 +578,14 @@ class VersionTestCase(BaseTestCase):
         build = BuildFactory()
         db.session.commit()
         with self.logged_user("package_admin"):
-            response = self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build.version.id]),
-            )
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build.version.id]),
+                )
         self.assert200(response)
-        self.assertIn("refreshed", response.data.decode())
+        self.assertIn("queued", response.data.decode())
 
     def test_action_resync_info_blocked_for_developer(self):
         build = BuildFactory()
@@ -560,13 +603,14 @@ class VersionTestCase(BaseTestCase):
         build = BuildFactory()
         db.session.commit()
         with self.logged_user("package_admin"):
-            response = self.client.post(
-                url_for("version.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_file", rowid=[build.version.id]),
-            )
+            with patch_resync_file():
+                response = self.client.post(
+                    url_for("version.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_file", rowid=[build.version.id]),
+                )
         self.assert200(response)
-        self.assertIn("refreshed", response.data.decode())
+        self.assertIn("queued", response.data.decode())
 
     def test_action_resync_file_blocked_for_developer(self):
         build = BuildFactory()
@@ -690,13 +734,14 @@ class BuildTestCase(BaseTestCase):
         db.session.commit()
 
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build.id]),
-            )
-            self.assert200(response)
-            self.assertIn("refreshed", response.data.decode())
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build.id]),
+                )
+                self.assert200(response)
+                self.assertIn("queued", response.data.decode())
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
@@ -714,13 +759,14 @@ class BuildTestCase(BaseTestCase):
         db.session.commit()
 
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build.id]),
-            )
-            self.assert200(response)
-            self.assertIn("refreshed", response.data.decode())
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build.id]),
+                )
+                self.assert200(response)
+                self.assertIn("queued", response.data.decode())
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
@@ -730,18 +776,18 @@ class BuildTestCase(BaseTestCase):
         )
 
     def test_action_resync_info_single_build_no_siblings_succeeds(self):
-        # A build with no siblings must resync cleanly.
         build = BuildFactory()
         db.session.commit()
         self.assertEqual(len(build.version.builds), 1)
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build.id]),
-            )
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build.id]),
+                )
         self.assert200(response)
-        self.assertIn("refreshed", response.data.decode())
+        self.assertIn("queued", response.data.decode())
 
     def test_action_resync_info_invalidates_cache(self):
         build = BuildFactory()
@@ -750,11 +796,12 @@ class BuildTestCase(BaseTestCase):
 
         app_cache.set("packages_versions", "stale")
         with self.logged_user("package_admin", "admin"):
-            self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build.id]),
-            )
+            with patch_resync_info():
+                self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build.id]),
+                )
         self.assertIsNone(app_cache.get("packages_versions"))
 
     def test_action_resync_file_invalidates_cache(self):
@@ -764,18 +811,15 @@ class BuildTestCase(BaseTestCase):
 
         app_cache.set("packages_versions", "stale")
         with self.logged_user("package_admin", "admin"):
-            self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_file", rowid=[build.id]),
-            )
+            with patch_resync_file():
+                self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_file", rowid=[build.id]),
+                )
         self.assertIsNone(app_cache.get("packages_versions"))
 
     def test_action_resync_info_rejects_inconsistent_sibling_build(self):
-        # Resyncing a single build must fail if its sibling SPK has different
-        # version-level metadata, to prevent last-write-wins corruption.
-        # Pin to distinct architectures so Build.generate_filename produces
-        # different paths for each build — otherwise one SPK overwrites the other.
         build1 = BuildFactory(architectures=[Architecture.find("88f628x")])
         build2 = BuildFactory(
             version=build1.version,
@@ -783,7 +827,6 @@ class BuildTestCase(BaseTestCase):
         )
         db.session.commit()
 
-        # Verify the two builds have different paths on disk.
         self.assertNotEqual(
             build1.path,
             build2.path,
@@ -802,7 +845,6 @@ class BuildTestCase(BaseTestCase):
             with create_spk(build2, info=info2) as spk:
                 f.write(spk.read())
 
-        # Sanity check: build1's SPK on disk must still have the original name.
         import io as _io
 
         from spkrepo.utils import SPK, extract_version_metadata
@@ -819,14 +861,20 @@ class BuildTestCase(BaseTestCase):
         )
 
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build1.id]),
-            )
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build1.id]),
+                )
         self.assert200(response)
-        self.assertIn("Failed", response.data.decode())
-        self.assertNotIn("refreshed", response.data.decode())
+        # Task runs synchronously but returns error result; DB must be unchanged.
+        db.session.expire_all()
+        unchanged = db.session.get(Build, build1.id)
+        self.assertEqual(
+            unchanged.version.displaynames["enu"].displayname,
+            original_displayname,
+        )
 
     def test_action_resync_file_visible_to_package_admin(self):
         with self.logged_user("package_admin"):
@@ -849,13 +897,14 @@ class BuildTestCase(BaseTestCase):
         db.session.commit()
 
         with self.logged_user("package_admin", "admin"):
-            response = self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_file", rowid=[build.id]),
-            )
-            self.assert200(response)
-            self.assertIn("refreshed", response.data.decode())
+            with patch_resync_file():
+                response = self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_file", rowid=[build.id]),
+                )
+                self.assert200(response)
+                self.assertIn("queued", response.data.decode())
 
         db.session.expire_all()
         refreshed_build = db.session.get(Build, build.id)
@@ -867,13 +916,14 @@ class BuildTestCase(BaseTestCase):
         build = BuildFactory()
         db.session.commit()
         with self.logged_user("package_admin"):
-            response = self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_info", rowid=[build.id]),
-            )
+            with patch_resync_info():
+                response = self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_info", rowid=[build.id]),
+                )
         self.assert200(response)
-        self.assertIn("refreshed", response.data.decode())
+        self.assertIn("queued", response.data.decode())
 
     def test_action_resync_info_blocked_for_developer(self):
         build = BuildFactory()
@@ -891,13 +941,14 @@ class BuildTestCase(BaseTestCase):
         build = BuildFactory()
         db.session.commit()
         with self.logged_user("package_admin"):
-            response = self.client.post(
-                url_for("build.action_view"),
-                follow_redirects=True,
-                data=dict(action="resync_file", rowid=[build.id]),
-            )
+            with patch_resync_file():
+                response = self.client.post(
+                    url_for("build.action_view"),
+                    follow_redirects=True,
+                    data=dict(action="resync_file", rowid=[build.id]),
+                )
         self.assert200(response)
-        self.assertIn("refreshed", response.data.decode())
+        self.assertIn("queued", response.data.decode())
 
     def test_action_resync_file_blocked_for_developer(self):
         build = BuildFactory()
@@ -946,7 +997,6 @@ class BuildTestCase(BaseTestCase):
         self.assert403(response)
 
     def test_developer_sees_only_maintainer_builds(self):
-        # A developer who is a maintainer on a package sees only that package's builds.
         with self.logged_user("developer") as user:
             own_package = PackageFactory(maintainers=[user])
             BuildFactory(version__package=own_package)

--- a/spkrepo/tests/test_tasks.py
+++ b/spkrepo/tests/test_tasks.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from flask import current_app
 
-from spkrepo.ext import db
+from spkrepo.ext import cache, db
 from spkrepo.models import Build
 from spkrepo.tests.common import (
     Architecture,
@@ -125,20 +125,16 @@ class ResyncBuildMetadataTaskTestCase(BaseTestCase):
     def test_invalidates_cache_on_success(self):
         build = BuildFactory()
         db.session.commit()
-        from spkrepo.ext import cache as app_cache
-
-        app_cache.set("packages_versions", "stale")
+        cache.set("packages_versions", "stale")
         result = resync_build_metadata(build.id, str(build))
 
         self.assertEqual(result["status"], "ok")
-        self.assertIsNone(app_cache.get("packages_versions"))
+        self.assertIsNone(cache.get("packages_versions"))
 
     def test_cache_not_invalidated_on_error(self):
         build = BuildFactory()
         db.session.commit()
-        from spkrepo.ext import cache as app_cache
-
-        app_cache.set("packages_versions", "stale")
+        cache.set("packages_versions", "stale")
         with patch(
             "spkrepo.views.tasks.extract_version_metadata",
             side_effect=ValueError("bad data"),
@@ -146,7 +142,7 @@ class ResyncBuildMetadataTaskTestCase(BaseTestCase):
             resync_build_metadata(build.id, str(build))
 
         # Cache must be untouched — the commit never ran
-        self.assertEqual(app_cache.get("packages_versions"), "stale")
+        self.assertEqual(cache.get("packages_versions"), "stale")
 
     def test_each_sibling_spk_opened_exactly_once(self):
         """Verify O(n) sibling reads: 3 builds → 3 SPK opens, no duplicates."""
@@ -250,22 +246,18 @@ class ResyncBuildFileTaskTestCase(BaseTestCase):
     def test_invalidates_cache_on_success(self):
         build = BuildFactory()
         db.session.commit()
-        from spkrepo.ext import cache as app_cache
-
-        app_cache.set("packages_versions", "stale")
+        cache.set("packages_versions", "stale")
         result = resync_build_file(build.id, str(build))
 
         self.assertEqual(result["status"], "ok")
-        self.assertIsNone(app_cache.get("packages_versions"))
+        self.assertIsNone(cache.get("packages_versions"))
 
     def test_cache_not_invalidated_on_error(self):
         build = BuildFactory()
         db.session.commit()
-        from spkrepo.ext import cache as app_cache
-
-        app_cache.set("packages_versions", "stale")
+        cache.set("packages_versions", "stale")
         # Use ValueError so it is caught without triggering the retry path
         with patch.object(Build, "calculate_size", side_effect=ValueError("bad size")):
             resync_build_file(build.id, str(build))
 
-        self.assertEqual(app_cache.get("packages_versions"), "stale")
+        self.assertEqual(cache.get("packages_versions"), "stale")

--- a/spkrepo/tests/test_tasks.py
+++ b/spkrepo/tests/test_tasks.py
@@ -1,0 +1,271 @@
+# -*- coding: utf-8 -*-
+import io
+import os
+from unittest.mock import MagicMock, patch
+
+from flask import current_app
+
+from spkrepo.ext import db
+from spkrepo.models import Build
+from spkrepo.tests.common import (
+    Architecture,
+    BaseTestCase,
+    BuildFactory,
+    create_info,
+    create_spk,
+)
+from spkrepo.views.tasks import resync_build_file, resync_build_metadata
+
+
+def _build_stub(build_id, path=None):
+    """Return a minimal Build-like object for testing skipped paths."""
+    stub = MagicMock(spec=Build)
+    stub.id = build_id
+    stub.path = path
+    return stub
+
+
+class ResyncBuildMetadataTaskTestCase(BaseTestCase):
+    """Unit tests for the resync_build_metadata Celery task."""
+
+    def test_success_restores_metadata_and_recalculates_md5(self):
+        build = BuildFactory()
+        db.session.commit()
+
+        original_display = build.version.displaynames["enu"].displayname
+        original_md5 = build.calculate_md5()
+
+        # Corrupt both a version-level and build-level field
+        build.version.displaynames["enu"].displayname = "Corrupted"
+        build.md5 = None
+        db.session.commit()
+
+        result = resync_build_metadata(build.id, str(build))
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["build_id"], build.id)
+        self.assertEqual(result["label"], str(build))
+
+        db.session.expire_all()
+        refreshed = db.session.get(Build, build.id)
+        self.assertEqual(
+            refreshed.version.displaynames["enu"].displayname, original_display
+        )
+        self.assertEqual(refreshed.md5, original_md5)
+
+    def test_skipped_when_build_not_found(self):
+        result = resync_build_metadata(999999, "nonexistent")
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["build_id"], 999999)
+
+    def test_skipped_when_build_has_no_path(self):
+        """Task must return skipped when build.path is None without hitting
+        the DB hooks."""
+        stub = _build_stub(build_id=1, path=None)
+        with patch("spkrepo.views.tasks.db.session.get", return_value=stub):
+            result = resync_build_metadata(1, "stub")
+        self.assertEqual(result["status"], "skipped")
+
+    def test_error_on_metadata_mismatch_between_siblings(self):
+        build1 = BuildFactory(architectures=[Architecture.find("88f628x")])
+        build2 = BuildFactory(
+            version=build1.version,
+            architectures=[Architecture.find("cedarview")],
+        )
+        db.session.commit()
+
+        # Write a mismatched displayname into build2's SPK on disk
+        existing_displayname = build1.version.displaynames["enu"].displayname
+        info2 = create_info(build2)
+        info2["displayname"] = existing_displayname + " MODIFIED"
+        info2["displayname_enu"] = existing_displayname + " MODIFIED"
+        spk2_path = os.path.join(current_app.config["DATA_PATH"], build2.path)
+        spk2_stream = create_spk(build2, info=info2)
+        with open(spk2_path, "wb") as f:
+            f.write(spk2_stream.read())
+
+        result = resync_build_metadata(build1.id, str(build1))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("mismatch", result["error"].lower())
+        # DB must be unchanged — rollback must have fired
+        db.session.expire_all()
+        self.assertEqual(
+            db.session.get(Build, build1.id).version.displaynames["enu"].displayname,
+            existing_displayname,
+        )
+
+    def test_error_on_missing_spk_file(self):
+        build = BuildFactory()
+        db.session.commit()
+
+        # Delete the file so the task hits a real FileNotFoundError on open
+        spk_path = os.path.join(current_app.config["DATA_PATH"], build.path)
+        os.remove(spk_path)
+
+        result = resync_build_metadata(build.id, str(build))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("build_id", result)
+
+    def test_does_not_retry_on_value_error(self):
+        """ValueError (e.g. metadata mismatch) must return error, never retry."""
+        build = BuildFactory()
+        db.session.commit()
+
+        with patch(
+            "spkrepo.views.tasks.extract_version_metadata",
+            side_effect=ValueError("bad data"),
+        ):
+            result = resync_build_metadata(build.id, str(build))
+
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error"], "bad data")
+
+    def test_invalidates_cache_on_success(self):
+        build = BuildFactory()
+        db.session.commit()
+        from spkrepo.ext import cache as app_cache
+
+        app_cache.set("packages_versions", "stale")
+        result = resync_build_metadata(build.id, str(build))
+
+        self.assertEqual(result["status"], "ok")
+        self.assertIsNone(app_cache.get("packages_versions"))
+
+    def test_cache_not_invalidated_on_error(self):
+        build = BuildFactory()
+        db.session.commit()
+        from spkrepo.ext import cache as app_cache
+
+        app_cache.set("packages_versions", "stale")
+        with patch(
+            "spkrepo.views.tasks.extract_version_metadata",
+            side_effect=ValueError("bad data"),
+        ):
+            resync_build_metadata(build.id, str(build))
+
+        # Cache must be untouched — the commit never ran
+        self.assertEqual(app_cache.get("packages_versions"), "stale")
+
+    def test_each_sibling_spk_opened_exactly_once(self):
+        """Verify O(n) sibling reads: 3 builds → 3 SPK opens, no duplicates."""
+        build1 = BuildFactory(architectures=[Architecture.find("88f628x")])
+        # These siblings exist to populate version.builds via the DB relationship;
+        # the task accesses them through build1.version.builds, not local variables
+        BuildFactory(
+            version=build1.version,
+            architectures=[Architecture.find("cedarview")],
+        )
+        BuildFactory(
+            version=build1.version,
+            architectures=[Architecture.find("qoriq")],
+        )
+        db.session.commit()
+        self.assertEqual(len(build1.version.builds), 3)
+
+        opened_paths = []
+        original_open = io.open
+
+        def counting_open(path, *args, **kwargs):
+            opened_paths.append(str(path))
+            return original_open(path, *args, **kwargs)
+
+        with patch("spkrepo.views.tasks.io.open", side_effect=counting_open):
+            result = resync_build_metadata(build1.id, str(build1))
+
+        self.assertEqual(result["status"], "ok")
+        spk_opens = [p for p in opened_paths if p.endswith(".spk")]
+        # build1 (own) + 2 siblings = exactly 3 opens
+        self.assertEqual(len(spk_opens), 3)
+        # No path opened more than once
+        self.assertEqual(len(spk_opens), len(set(spk_opens)))
+
+
+class ResyncBuildFileTaskTestCase(BaseTestCase):
+    """Unit tests for the resync_build_file Celery task."""
+
+    def test_success_recalculates_md5_and_size(self):
+        build = BuildFactory()
+        db.session.commit()
+
+        expected_md5 = build.calculate_md5()
+        build.md5 = None
+        build.size = None
+        db.session.commit()
+
+        result = resync_build_file(build.id, str(build))
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["build_id"], build.id)
+        self.assertEqual(result["label"], str(build))
+
+        db.session.expire_all()
+        refreshed = db.session.get(Build, build.id)
+        self.assertEqual(refreshed.md5, expected_md5)
+        self.assertIsNotNone(refreshed.size)
+        self.assertGreater(refreshed.size, 0)
+
+    def test_skipped_when_build_not_found(self):
+        result = resync_build_file(999999, "nonexistent")
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["build_id"], 999999)
+
+    def test_skipped_when_build_has_no_path(self):
+        """Task must return skipped when build.path is None without hitting
+        the DB hooks."""
+        stub = _build_stub(build_id=1, path=None)
+        with patch("spkrepo.views.tasks.db.session.get", return_value=stub):
+            result = resync_build_file(1, "stub")
+        self.assertEqual(result["status"], "skipped")
+
+    def test_error_on_missing_spk_file(self):
+        build = BuildFactory()
+        db.session.commit()
+
+        spk_path = os.path.join(current_app.config["DATA_PATH"], build.path)
+        os.remove(spk_path)
+
+        result = resync_build_file(build.id, str(build))
+        self.assertEqual(result["status"], "error")
+
+    def test_error_does_not_persist_partial_changes(self):
+        """If calculate_size raises after calculate_md5 succeeds, neither
+        change should be committed to the DB."""
+        build = BuildFactory()
+        db.session.commit()
+
+        original_md5 = build.md5
+
+        # Use ValueError so it is caught without triggering the retry path
+        with patch.object(Build, "calculate_size", side_effect=ValueError("bad size")):
+            result = resync_build_file(build.id, str(build))
+
+        self.assertEqual(result["status"], "error")
+        self.assertIn("bad size", result["error"])
+        db.session.expire_all()
+        # md5 must not have been committed despite calculate_md5 succeeding
+        self.assertEqual(db.session.get(Build, build.id).md5, original_md5)
+
+    def test_invalidates_cache_on_success(self):
+        build = BuildFactory()
+        db.session.commit()
+        from spkrepo.ext import cache as app_cache
+
+        app_cache.set("packages_versions", "stale")
+        result = resync_build_file(build.id, str(build))
+
+        self.assertEqual(result["status"], "ok")
+        self.assertIsNone(app_cache.get("packages_versions"))
+
+    def test_cache_not_invalidated_on_error(self):
+        build = BuildFactory()
+        db.session.commit()
+        from spkrepo.ext import cache as app_cache
+
+        app_cache.set("packages_versions", "stale")
+        # Use ValueError so it is caught without triggering the retry path
+        with patch.object(Build, "calculate_size", side_effect=ValueError("bad size")):
+            resync_build_file(build.id, str(build))
+
+        self.assertEqual(app_cache.get("packages_versions"), "stale")

--- a/spkrepo/views/__init__.py
+++ b/spkrepo/views/__init__.py
@@ -7,6 +7,7 @@ from .admin import (
     PackageView,
     ScreenshotView,
     ServiceView,
+    TaskStatusView,
     UserView,
     VersionView,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "ScreenshotView",
     "ServiceView",
     "UserView",
+    "TaskStatusView",
     "VersionView",
     "api",
     "SpkrepoRegisterForm",

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -2,10 +2,20 @@
 import io
 import os
 import shutil
+import uuid
 from datetime import date, timedelta
 
 from celery.result import AsyncResult
-from flask import abort, current_app, flash, jsonify, redirect, request, url_for
+from flask import (
+    abort,
+    current_app,
+    flash,
+    jsonify,
+    redirect,
+    request,
+    session,
+    url_for,
+)
 from flask_admin import AdminIndexView, BaseView, expose
 from flask_admin.actions import action
 from flask_admin.contrib.sqla import ModelView
@@ -65,6 +75,42 @@ def _flash_action_results(successes, failures, skipped=None, item_label="item"):
         )
     for name, message in failures:
         flash(f"Failed to process {name}: {message}", "error")
+
+
+def _task_redis_key():
+    """Return a per-user Redis key for storing task IDs.
+
+    The key is stored in the session cookie as a short UUID — only 36 bytes,
+    well within the 4KB cookie limit regardless of how many tasks are queued.
+    The task ID list itself lives in Redis.
+    """
+
+    key = session.get("resync_task_key")
+    if not key:
+        key = f"resync_tasks:{uuid.uuid4()}"
+        session["resync_task_key"] = key
+    return key
+
+
+def _store_task_ids(new_ids):
+    """Append new task IDs to the user's Redis-backed task list."""
+    key = _task_redis_key()
+    existing = cache.get(key) or []
+    cache.set(key, existing + new_ids, timeout=86400)  # match result_expires
+
+
+def _get_task_ids():
+    """Return the current user's task ID list from Redis."""
+    key = _task_redis_key()
+    return cache.get(key) or []
+
+
+def _clear_task_ids():
+    """Remove the current user's task ID list from Redis."""
+
+    key = session.pop("resync_task_key", None)
+    if key:
+        cache.delete(key)
 
 
 # ---------------------------------------------------------------------------
@@ -272,11 +318,7 @@ class SignResyncMixin:
             result = resync_build_metadata.delay(build.id, str(build))
             task_ids.append(result.id)
         if task_ids:
-            # Store in session so TaskStatusView can display them
-            from flask import session as flask_session
-
-            existing = flask_session.get("resync_task_ids", [])
-            flask_session["resync_task_ids"] = existing + task_ids
+            _store_task_ids(task_ids)
             count = len(task_ids)
             flash(
                 Markup(
@@ -299,10 +341,7 @@ class SignResyncMixin:
             result = resync_build_file.delay(build.id, str(build))
             task_ids.append(result.id)
         if task_ids:
-            from flask import session as flask_session
-
-            existing = flask_session.get("resync_task_ids", [])
-            flask_session["resync_task_ids"] = existing + task_ids
+            _store_task_ids(task_ids)
             count = len(task_ids)
             flash(
                 Markup(
@@ -553,9 +592,7 @@ class PackageView(ModelView):
         return super().details_view()
 
     def _get_arch_breakdown(self):
-        from flask import request as flask_request
-
-        pkg_id = flask_request.args.get("id", type=int)
+        pkg_id = request.args.get("id", type=int)
         if not pkg_id:
             return None
         cutoff = date.today() - timedelta(days=90)
@@ -1059,9 +1096,7 @@ class TaskStatusView(BaseView):
 
     @expose("/")
     def index(self):
-        from flask import session as flask_session
-
-        task_ids = flask_session.get("resync_task_ids", [])
+        task_ids = _get_task_ids()
         tasks = []
         pending_count = 0
         for task_id in task_ids:
@@ -1086,16 +1121,11 @@ class TaskStatusView(BaseView):
 
     @expose("/status/")
     def status_json(self):
-        """JSON endpoint polled by the page's auto-refresh.
-        Access is gated by is_accessible — unauthenticated or unauthorised
-        requests are rejected before this method is reached.
-        """
+        """JSON endpoint polled by the page's auto-refresh."""
         if not self.is_accessible():
             return jsonify({"error": "forbidden"}), 403
 
-        from flask import session as flask_session
-
-        task_ids = flask_session.get("resync_task_ids", [])
+        task_ids = _get_task_ids()
         tasks = []
         pending_count = 0
         for task_id in task_ids:
@@ -1126,10 +1156,8 @@ class TaskStatusView(BaseView):
 
     @expose("/clear/", methods=["POST"])
     def clear(self):
-        """Clear the current session's task list."""
+        """Clear the current user's task list from Redis."""
         if not self.is_accessible():
             abort(403)
-        from flask import session as flask_session
-
-        flask_session.pop("resync_task_ids", None)
+        _clear_task_ids()
         return redirect(url_for("tasks.index"))

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -4,8 +4,9 @@ import os
 import shutil
 from datetime import date, timedelta
 
-from flask import abort, current_app, flash, redirect, request, url_for
-from flask_admin import AdminIndexView, expose
+from celery.result import AsyncResult
+from flask import abort, current_app, flash, jsonify, redirect, request, url_for
+from flask_admin import AdminIndexView, BaseView, expose
 from flask_admin.actions import action
 from flask_admin.contrib.sqla import ModelView
 from flask_admin.contrib.sqla.form import get_form
@@ -17,7 +18,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from wtforms import PasswordField
 from wtforms.validators import Regexp
 
-from ..ext import cache, db
+from ..ext import cache, celery, db
 from ..models import (
     Architecture,
     Build,
@@ -30,6 +31,7 @@ from ..models import (
     Version,
 )
 from ..utils import SPK, apply_info_from_spk, extract_version_metadata
+from .tasks import resync_build_file, resync_build_metadata
 
 # ---------------------------------------------------------------------------
 # Shared formatters
@@ -264,18 +266,26 @@ class SignResyncMixin:
         "Reapply INFO metadata from selected builds?",
     )
     def action_resync_info(self, ids):
-        successes, failures = [], []
+        task_ids = []
         for label, build in self._iter_builds(ids):
-            try:
-                _resync_build_metadata(db.session, build)
-                db.session.commit()
-                successes.append(label)
-            except Exception as exc:
-                db.session.rollback()
-                failures.append((label, str(exc)))
-        if successes:
-            cache.delete("packages_versions")
-        _flash_action_results(successes, failures, item_label="build")
+            result = resync_build_metadata.delay(build.id, str(build))
+            task_ids.append(result.id)
+        if task_ids:
+            # Store in session so TaskStatusView can display them
+            from flask import session as flask_session
+
+            existing = flask_session.get("resync_task_ids", [])
+            flask_session["resync_task_ids"] = existing + task_ids
+            count = len(task_ids)
+            flash(
+                Markup(
+                    f"{count} resync task(s) queued. "
+                    f'<a href="/admin/tasks/">View status</a>',
+                ),
+                "info",
+            )
+        else:
+            flash("No builds found to resync.", "warning")
 
     @action(
         "resync_file",
@@ -283,18 +293,25 @@ class SignResyncMixin:
         "Recalculate md5 and size from selected build files?",
     )
     def action_resync_file(self, ids):
-        successes, failures = [], []
+        task_ids = []
         for label, build in self._iter_builds(ids):
-            try:
-                _resync_build_file(build)
-                db.session.commit()
-                successes.append(label)
-            except Exception as exc:
-                db.session.rollback()
-                failures.append((label, str(exc)))
-        if successes:
-            cache.delete("packages_versions")
-        _flash_action_results(successes, failures, item_label="build")
+            result = resync_build_file.delay(build.id, str(build))
+            task_ids.append(result.id)
+        if task_ids:
+            from flask import session as flask_session
+
+            existing = flask_session.get("resync_task_ids", [])
+            flask_session["resync_task_ids"] = existing + task_ids
+            count = len(task_ids)
+            flash(
+                Markup(
+                    f"{count} file resync task(s) queued. "
+                    f'<a href="/admin/tasks/">View status</a>',
+                ),
+                "info",
+            )
+        else:
+            flash("No builds found to resync.", "warning")
 
 
 # ---------------------------------------------------------------------------
@@ -1021,3 +1038,84 @@ class IndexView(AdminIndexView):
             ),
             recent_versions=recent_versions,
         )
+
+
+# ---------------------------------------------------------------------------
+# Task status
+# ---------------------------------------------------------------------------
+
+
+class TaskStatusView(BaseView):
+    """Admin panel page showing the status of queued resync tasks."""
+
+    def is_accessible(self):
+        return current_user.is_authenticated and any(
+            current_user.has_role(r) for r in ("developer", "package_admin", "admin")
+        )
+
+    def inaccessible_callback(self, name, **kwargs):
+        return redirect(url_for("security.login"))
+
+    @expose("/")
+    def index(self):
+        from flask import session as flask_session
+
+        task_ids = flask_session.get("resync_task_ids", [])
+        tasks = []
+        pending_count = 0
+        for task_id in task_ids:
+            result = AsyncResult(task_id, app=celery)
+            state = result.state  # PENDING, STARTED, SUCCESS, FAILURE, RETRY
+            info = result.info if result.ready() else None
+            if state in ("PENDING", "STARTED", "RETRY"):
+                pending_count += 1
+            tasks.append(
+                {
+                    "id": task_id,
+                    "state": state,
+                    "result": info,
+                }
+            )
+        # Auto-clear completed tasks older than the current batch once all done
+        if task_ids and pending_count == 0:
+            flask_session["resync_task_ids"] = []
+
+        return self.render(
+            "admin/task_status.html",
+            tasks=tasks,
+            pending_count=pending_count,
+        )
+
+    @expose("/status/")
+    def status_json(self):
+        """JSON endpoint polled by the page's auto-refresh."""
+        from flask import session as flask_session
+
+        task_ids = flask_session.get("resync_task_ids", [])
+        tasks = []
+        pending_count = 0
+        for task_id in task_ids:
+            result = AsyncResult(task_id, app=celery)
+            state = result.state
+            info = result.info if result.ready() else None
+            label = (
+                (info or {}).get("label", task_id)
+                if isinstance(info, dict)
+                else task_id
+            )
+            error = (
+                (info or {}).get("error")
+                if isinstance(info, dict)
+                else (str(info) if info else None)
+            )
+            if state in ("PENDING", "STARTED", "RETRY"):
+                pending_count += 1
+            tasks.append(
+                {
+                    "id": task_id,
+                    "state": state,
+                    "label": label,
+                    "error": error,
+                }
+            )
+        return jsonify({"tasks": tasks, "pending_count": pending_count})

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -13,6 +13,7 @@ from flask_admin.contrib.sqla.form import get_form
 from flask_admin.contrib.sqla.tools import get_query_for_ids
 from flask_admin.form import ImageUploadField
 from flask_security import current_user
+from flask_wtf.csrf import generate_csrf
 from markupsafe import Markup
 from sqlalchemy.exc import SQLAlchemyError
 from wtforms import PasswordField
@@ -1065,7 +1066,7 @@ class TaskStatusView(BaseView):
         pending_count = 0
         for task_id in task_ids:
             result = AsyncResult(task_id, app=celery)
-            state = result.state  # PENDING, STARTED, SUCCESS, FAILURE, RETRY
+            state = result.state
             info = result.info if result.ready() else None
             if state in ("PENDING", "STARTED", "RETRY"):
                 pending_count += 1
@@ -1076,19 +1077,22 @@ class TaskStatusView(BaseView):
                     "result": info,
                 }
             )
-        # Auto-clear completed tasks older than the current batch once all done
-        if task_ids and pending_count == 0:
-            flask_session["resync_task_ids"] = []
-
         return self.render(
             "admin/task_status.html",
             tasks=tasks,
             pending_count=pending_count,
+            csrf_token=generate_csrf,
         )
 
     @expose("/status/")
     def status_json(self):
-        """JSON endpoint polled by the page's auto-refresh."""
+        """JSON endpoint polled by the page's auto-refresh.
+        Access is gated by is_accessible — unauthenticated or unauthorised
+        requests are rejected before this method is reached.
+        """
+        if not self.is_accessible():
+            return jsonify({"error": "forbidden"}), 403
+
         from flask import session as flask_session
 
         task_ids = flask_session.get("resync_task_ids", [])
@@ -1119,3 +1123,13 @@ class TaskStatusView(BaseView):
                 }
             )
         return jsonify({"tasks": tasks, "pending_count": pending_count})
+
+    @expose("/clear/", methods=["POST"])
+    def clear(self):
+        """Clear the current session's task list."""
+        if not self.is_accessible():
+            abort(403)
+        from flask import session as flask_session
+
+        flask_session.pop("resync_task_ids", None)
+        return redirect(url_for("tasks.index"))

--- a/spkrepo/views/tasks.py
+++ b/spkrepo/views/tasks.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+import io
+import os
+
+from flask import current_app
+
+from ..ext import cache, celery, db
+from ..models import Build
+from ..utils import SPK, apply_info_from_spk, extract_version_metadata
+
+
+@celery.task(bind=True, max_retries=3, default_retry_delay=10)
+def resync_build_metadata(self, build_id, build_label):
+    """Re-read the SPK file for a build and reapply its metadata to the DB."""
+    build = db.session.get(Build, build_id)
+    if not build or not build.path:
+        return {"status": "skipped", "build_id": build_id, "label": build_label}
+
+    try:
+        file_path = os.path.join(current_app.config["DATA_PATH"], build.path)
+        with io.open(file_path, "rb") as stream:
+            spk = SPK(stream)
+            incoming_meta = extract_version_metadata(spk)
+
+            for sibling in build.version.builds:
+                if sibling.id == build.id or not sibling.path:
+                    continue
+                sibling_path = os.path.join(
+                    current_app.config["DATA_PATH"], sibling.path
+                )
+                with io.open(sibling_path, "rb") as s2:
+                    sibling_meta = extract_version_metadata(SPK(s2))
+                if sibling_meta != incoming_meta:
+                    raise ValueError(
+                        f"Version-level metadata mismatch between "
+                        f"{os.path.basename(build.path)} and "
+                        f"{os.path.basename(sibling.path)} — resync aborted."
+                    )
+
+            md5 = spk.calculate_md5()
+            apply_info_from_spk(db.session, build, spk, md5)
+            db.session.commit()
+            cache.delete("packages_versions")
+
+        return {"status": "ok", "build_id": build_id, "label": build_label}
+
+    except ValueError as exc:
+        # Data errors (mismatch, bad path, etc.) — don't retry
+        db.session.rollback()
+        return {
+            "status": "error",
+            "build_id": build_id,
+            "label": build_label,
+            "error": str(exc),
+        }
+
+    except Exception as exc:
+        db.session.rollback()
+        try:
+            raise self.retry(exc=exc)
+        except self.MaxRetriesExceededError:
+            return {
+                "status": "error",
+                "build_id": build_id,
+                "label": build_label,
+                "error": str(exc),
+            }
+
+
+@celery.task(bind=True, max_retries=3, default_retry_delay=10)
+def resync_build_file(self, build_id, build_label):
+    """Recalculate md5 and size for a build from its file on disk."""
+    build = db.session.get(Build, build_id)
+    if not build or not build.path:
+        return {"status": "skipped", "build_id": build_id, "label": build_label}
+
+    try:
+        build.md5 = build.calculate_md5()
+        build.size = build.calculate_size()
+        db.session.commit()
+        cache.delete("packages_versions")
+        return {"status": "ok", "build_id": build_id, "label": build_label}
+
+    except (ValueError, FileNotFoundError) as exc:
+        db.session.rollback()
+        return {
+            "status": "error",
+            "build_id": build_id,
+            "label": build_label,
+            "error": str(exc),
+        }
+
+    except Exception as exc:
+        db.session.rollback()
+        try:
+            raise self.retry(exc=exc)
+        except self.MaxRetriesExceededError:
+            return {
+                "status": "error",
+                "build_id": build_id,
+                "label": build_label,
+                "error": str(exc),
+            }

--- a/spkrepo/views/tasks.py
+++ b/spkrepo/views/tasks.py
@@ -9,25 +9,31 @@ from ..models import Build
 from ..utils import SPK, apply_info_from_spk, extract_version_metadata
 
 
-@celery.task(bind=True, max_retries=3, default_retry_delay=10)
+@celery.task(bind=True, max_retries=3, default_retry_delay=10, queue="resync")
 def resync_build_metadata(self, build_id, build_label):
-    """Re-read the SPK file for a build and reapply its metadata to the DB."""
+    """Re-read the SPK file for a build and reapply its metadata to the DB.
+
+    Sibling SPK files are read once each and compared against the target
+    build's metadata, avoiding the O(n²) I/O of the original synchronous
+    implementation.
+    """
     build = db.session.get(Build, build_id)
     if not build or not build.path:
         return {"status": "skipped", "build_id": build_id, "label": build_label}
 
     try:
-        file_path = os.path.join(current_app.config["DATA_PATH"], build.path)
+        data_path = current_app.config["DATA_PATH"]
+        file_path = os.path.join(data_path, build.path)
+
         with io.open(file_path, "rb") as stream:
             spk = SPK(stream)
             incoming_meta = extract_version_metadata(spk)
 
+            # Read each sibling once and compare — O(n) instead of O(n²)
             for sibling in build.version.builds:
                 if sibling.id == build.id or not sibling.path:
                     continue
-                sibling_path = os.path.join(
-                    current_app.config["DATA_PATH"], sibling.path
-                )
+                sibling_path = os.path.join(data_path, sibling.path)
                 with io.open(sibling_path, "rb") as s2:
                     sibling_meta = extract_version_metadata(SPK(s2))
                 if sibling_meta != incoming_meta:
@@ -44,8 +50,8 @@ def resync_build_metadata(self, build_id, build_label):
 
         return {"status": "ok", "build_id": build_id, "label": build_label}
 
-    except ValueError as exc:
-        # Data errors (mismatch, bad path, etc.) — don't retry
+    except (ValueError, FileNotFoundError) as exc:
+        # Data errors (mismatch, missing file, etc.) — don't retry
         db.session.rollback()
         return {
             "status": "error",
@@ -67,7 +73,7 @@ def resync_build_metadata(self, build_id, build_label):
             }
 
 
-@celery.task(bind=True, max_retries=3, default_retry_delay=10)
+@celery.task(bind=True, max_retries=3, default_retry_delay=10, queue="resync")
 def resync_build_file(self, build_id, build_label):
     """Recalculate md5 and size for a build from its file on disk."""
     build = db.session.get(Build, build_id)

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,18 @@ wheels = [
 ]
 
 [[package]]
+name = "amqp"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/fc/ec94a357dfc6683d8c86f8b4cfa5416a4c36b28052ec8260c77aca96a443/amqp-5.3.1.tar.gz", hash = "sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432", size = 129013, upload-time = "2024-11-12T19:55:44.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/99/fc813cd978842c26c82534010ea849eee9ab3a13ea2b74e95cb9c99e747b/amqp-5.3.1-py3-none-any.whl", hash = "sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2", size = 50944, upload-time = "2024-11-12T19:55:41.782Z" },
+]
+
+[[package]]
 name = "aniso8601"
 version = "10.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -110,6 +122,15 @@ wheels = [
 ]
 
 [[package]]
+name = "billiard"
+version = "4.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -153,6 +174,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/a5/5eb041dbee71766704d44cf5dfb6950ab018be0fd02cd763ade09869e33c/cachelib-0.14.0.tar.gz", hash = "sha256:73fedcadd0ba818fb2bb9f3c7cd5fcc2a71e86286f1842f55f28d500faee17f1", size = 170320, upload-time = "2026-05-09T16:16:02.896Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/0e/5493f2078dece836979f4e28e3b2066064a6d66691d4b0888efc7c62f702/cachelib-0.14.0-py3-none-any.whl", hash = "sha256:4671000b032baa8fac47ad19850f4f522785cee764b4e04c5cfe8955a18d67de", size = 22746, upload-time = "2026-05-09T16:16:01.68Z" },
+]
+
+[[package]]
+name = "celery"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "billiard" },
+    { name = "click" },
+    { name = "click-didyoumean" },
+    { name = "click-plugins" },
+    { name = "click-repl" },
+    { name = "kombu" },
+    { name = "python-dateutil" },
+    { name = "tzlocal" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/b4/a1233943ab5c8ea05fb877a88a0a0622bf47444b99e4991a8045ac37ea1d/celery-5.6.3.tar.gz", hash = "sha256:177006bd2054b882e9f01be59abd8529e88879ef50d7918a7050c5a9f4e12912", size = 1742243, upload-time = "2026-03-26T12:14:51.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/c9/6eccdda96e098f7ae843162db2d3c149c6931a24fda69fe4ab84d0027eb5/celery-5.6.3-py3-none-any.whl", hash = "sha256:0808f42f80909c4d5833202360ffafb2a4f83f4d8e23e1285d926610e9a7afa6", size = 451235, upload-time = "2026-03-26T12:14:49.491Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "kombu", extra = ["redis"] },
 ]
 
 [[package]]
@@ -256,6 +302,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
+]
+
+[[package]]
+name = "click-didyoumean"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz", hash = "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463", size = 3089, upload-time = "2024-03-24T08:22:07.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl", hash = "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c", size = 3631, upload-time = "2024-03-24T08:22:06.356Z" },
+]
+
+[[package]]
+name = "click-plugins"
+version = "1.1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/34847b59150da33690a36da3681d6bbc2ec14ee9a846bc30a6746e5984e4/click_plugins-1.1.1.2.tar.gz", hash = "sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261", size = 8343, upload-time = "2025-06-25T00:47:37.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9a/2abecb28ae875e39c8cad711eb1186d8d14eab564705325e77e4e6ab9ae5/click_plugins-1.1.1.2-py2.py3-none-any.whl", hash = "sha256:008d65743833ffc1f5417bf0e78e8d2c23aab04d9745ba817bd3e71b0feb6aa6", size = 11051, upload-time = "2025-06-25T00:47:36.731Z" },
+]
+
+[[package]]
+name = "click-repl"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/a2/57f4ac79838cfae6912f997b4d1a64a858fb0c86d7fcaae6f7b58d267fca/click-repl-0.3.0.tar.gz", hash = "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9", size = 10449, upload-time = "2023-06-15T12:43:51.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl", hash = "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812", size = 10289, upload-time = "2023-06-15T12:43:48.626Z" },
 ]
 
 [[package]]
@@ -676,6 +759,26 @@ wheels = [
 ]
 
 [[package]]
+name = "kombu"
+version = "5.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "amqp" },
+    { name = "packaging" },
+    { name = "tzdata" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
 name = "libpass"
 version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
@@ -970,6 +1073,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "psycopg2"
 version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,6 +1207,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
 ]
 
 [[package]]
@@ -1273,6 +1397,7 @@ dependencies = [
     { name = "alembic" },
     { name = "bcrypt" },
     { name = "boto3" },
+    { name = "celery", extra = ["redis"] },
     { name = "click" },
     { name = "configparser" },
     { name = "flask" },
@@ -1314,6 +1439,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.17.2" },
     { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "boto3", specifier = ">=1.34" },
+    { name = "celery", extras = ["redis"], specifier = ">=5.3" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "configparser", specifier = ">=7.2.0" },
     { name = "flask", specifier = ">=3.1.2" },
@@ -1410,12 +1536,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "vine"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
 ]
 
 [[package]]
@@ -1431,6 +1578,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/f0/b47ecf438211a25a97f8f0e4b23c22bc2496ebfea18dd6ec16210f09cc36/virtualenv-21.4.1.tar.gz", hash = "sha256:2ca543c713b72840ceffd94e9bdedfbd09a661defa1f7f69e5429ad4059442e2", size = 7613344, upload-time = "2026-05-28T04:12:49.905Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/dc/ac4f3a987a87e1a18556896f257c4e15c95ed157b7975347ec6b313b75ce/virtualenv-21.4.1-py3-none-any.whl", hash = "sha256:caf4ff72d1b4039057f41d8e8466e859513d67c0400d9c6b62c02c9d1ebc3e12", size = 7594078, upload-time = "2026-05-28T04:12:47.686Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Running "Resync Info" or "Resync File" on a large number of builds causes
the Gunicorn worker to time out and crash. Each resync requires reading and
checksumming SPK files synchronously within a single HTTP request, and the
metadata resync also reads every sibling build's SPK for each build
processed, making the operation O(n²) in I/O.

## Solution

Move both resync operations off the request thread into Celery background
tasks, so the HTTP response returns immediately regardless of batch size.
A live status page in the admin panel lets the user track progress without
polling manually.

## Changes

### New files
- **`spkrepo/views/tasks.py`** — `resync_build_metadata` and
  `resync_build_file` Celery tasks with retry logic, structured result
  payloads, named `resync` queue, and O(n) sibling reads
- **`templates/admin/task_status.html`** — auto-polling status page that
  updates live while tasks are running, with a Clear button to reset the
  session between batches
- **`celery_app.py`** — worker entry point for both local dev and production
- **`docker-compose.worker.yml`** — optional compose overlay to run the
  worker locally when end-to-end async testing is needed
- **`spkrepo/tests/test_tasks.py`** — full unit test suite for both tasks
  covering success, skipped, error, cache invalidation, rollback, and O(n)
  sibling read verification

### Modified files
- **`spkrepo/views/admin.py`** — replace synchronous resync action bodies
  with `.delay()` calls; add `TaskStatusView` with live polling, CSRF-protected
  Clear endpoint, and access-guarded JSON status endpoint; import
  `generate_csrf` from `flask_wtf.csrf`
- **`spkrepo/views/__init__.py`** — export `TaskStatusView`
- **`spkrepo/ext.py`** — add `celery = Celery()` extension instance
- **`spkrepo/app.py`** — wire Celery into the app factory with a `FlaskTask`
  context wrapper; expose configured instance via `app.extensions["celery"]`;
  register `TaskStatusView` with Flask-Admin
- **`pyproject.toml`** — add `celery[redis]>=5.3` dependency
- **`config.py`** — add `CELERY` config block with env var overrides for
  broker and result backend URLs, `result_expires` of 24 hours, and named
  `resync` queue definition
- **`spkrepo/tests/test_admin.py`** — patch `.delay()` to run tasks
  synchronously in tests; update resync assertions to match queued behaviour

## Technical details

**O(n) sibling reads** — the original synchronous code re-opened every
sibling SPK for each build in a batch. The task reads each sibling exactly
once per task execution, verified by a test that counts `io.open` calls.

**Named queue** — both tasks use `queue="resync"` so resync work is isolated
and cannot starve other Celery tasks added in future. The worker must be
started with `--queues resync`.

**Error handling** — `ValueError` and `FileNotFoundError` are treated as
data errors and return an error result without retrying. Transient failures
retry up to 3 times with a 10-second delay before returning an error result.
`FileNotFoundError` is caught in both tasks consistently.

**CSRF** — the Clear button on the status page uses a POST form with a
`generate_csrf` token passed from the view, following the standard
Flask-WTF pattern for non-form views.

## Testing

All existing admin tests pass. Resync tests mock `.delay()` to execute tasks
inline so no broker is required to run the test suite. A
`docker-compose.worker.yml` overlay is provided for manual end-to-end
testing of the full async flow. The new `test_tasks.py` covers both task
functions directly with 15 tests across success, skipped, error, cache, and
rollback scenarios.

## Deployment notes

- Redis is already present in both the dev and production compose stacks —
  no new infrastructure required
- Add `celery[redis]>=5.3` to the environment before deploying
- Start the worker with:
  `celery -A "celery_app:celery_app" worker --loglevel=info --concurrency=4 --queues resync`
- Set `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND` env vars if the Redis
  hostname differs from `localhost` (e.g. `redis` inside Docker)