### PR TITLE
Admin: resolve UniqueViolation and stale NAS catalog cache

### DIFF
--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -583,150 +583,157 @@ def apply_info_from_spk(session, build, spk, md5_hash):
     :param md5_hash: pre-calculated MD5 hex string of the SPK file
     :raises ValueError: on any validation failure (package mismatch, bad version, etc.)
     """
-    info = spk.info
-    package = build.version.package
+    with session.no_autoflush:
+        info = spk.info
+        package = build.version.package
 
-    if info.get("package") != package.name:
-        raise ValueError("INFO package does not match build package")
+        if info.get("package") != package.name:
+            raise ValueError("INFO package does not match build package")
 
-    version_match = version_re.match(info.get("version", ""))
-    if not version_match:
-        raise ValueError("Invalid INFO version value")
+        version_match = version_re.match(info.get("version", ""))
+        if not version_match:
+            raise ValueError("Invalid INFO version value")
 
-    version_number = int(version_match.group("version"))
-    if version_number != build.version.version:
-        raise ValueError("INFO version does not match build version")
+        version_number = int(version_match.group("version"))
+        if version_number != build.version.version:
+            raise ValueError("INFO version does not match build version")
 
-    # -- Version-level fields ------------------------------------------------
+        # -- Version-level fields ------------------------------------------------
 
-    version = build.version
-    version.upstream_version = version_match.group("upstream_version")
-    version.changelog = info.get("changelog")
-    version.report_url = info.get("report_url")
-    version.distributor = info.get("distributor")
-    version.distributor_url = info.get("distributor_url")
-    version.maintainer = info.get("maintainer")
-    version.maintainer_url = info.get("maintainer_url")
-    version.install_wizard = "install" in spk.wizards
-    version.upgrade_wizard = "upgrade" in spk.wizards
+        version = build.version
+        version.upstream_version = version_match.group("upstream_version")
+        version.changelog = info.get("changelog")
+        version.report_url = info.get("report_url")
+        version.distributor = info.get("distributor")
+        version.distributor_url = info.get("distributor_url")
+        version.maintainer = info.get("maintainer")
+        version.maintainer_url = info.get("maintainer_url")
+        version.install_wizard = "install" in spk.wizards
+        version.upgrade_wizard = "upgrade" in spk.wizards
 
-    startable = True  # default per Synology docs
-    if info.get("startable") is False or info.get("ctl_stop") is False:
-        startable = False
-    version.startable = startable
+        startable = True  # default per Synology docs
+        if info.get("startable") is False or info.get("ctl_stop") is False:
+            startable = False
+        version.startable = startable
 
-    version.license = spk.license
-    version.service_dependencies = resolve_services(info.get("install_dep_services"))
-
-    version.displaynames.clear()
-    default_display = info.get("displayname")
-    if default_display:
-        language = Language.find("enu")
-        if language is None:
-            raise ValueError("Language 'enu' is not defined")
-        version.displaynames[language.code] = DisplayName(
-            language=language, displayname=default_display
+        version.license = spk.license
+        version.service_dependencies = resolve_services(
+            info.get("install_dep_services")
         )
-    for key, value in info.items():
-        if key.startswith("displayname_"):
-            language_code = key.split("_", 1)[1]
-            language = Language.find(language_code)
+
+        version.displaynames.clear()
+        default_display = info.get("displayname")
+        if default_display:
+            language = Language.find("enu")
             if language is None:
-                raise ValueError(f"Unknown INFO displayname language: {language_code}")
+                raise ValueError("Language 'enu' is not defined")
             version.displaynames[language.code] = DisplayName(
-                language=language, displayname=value
+                language=language, displayname=default_display
             )
+        for key, value in info.items():
+            if key.startswith("displayname_"):
+                language_code = key.split("_", 1)[1]
+                language = Language.find(language_code)
+                if language is None:
+                    raise ValueError(
+                        f"Unknown INFO displayname language: {language_code}"
+                    )
+                version.displaynames[language.code] = DisplayName(
+                    language=language, displayname=value
+                )
 
-    version.descriptions.clear()
-    default_description = info.get("description")
-    if default_description:
-        language = Language.find("enu")
-        if language is None:
-            raise ValueError("Language 'enu' is not defined")
-        version.descriptions[language.code] = Description(
-            language=language, description=default_description
-        )
-    for key, value in info.items():
-        if key.startswith("description_"):
-            language_code = key.split("_", 1)[1]
-            language = Language.find(language_code)
+        version.descriptions.clear()
+        default_description = info.get("description")
+        if default_description:
+            language = Language.find("enu")
             if language is None:
-                raise ValueError(f"Unknown INFO description language: {language_code}")
+                raise ValueError("Language 'enu' is not defined")
             version.descriptions[language.code] = Description(
-                language=language, description=value
+                language=language, description=default_description
             )
-
-    # Icon files are written to disk here. If anything raises after this point
-    # the caller's session rollback will undo the DB changes but the files will
-    # remain on disk — see docstring note above.
-    existing_icons = dict(version.icons)
-    new_sizes = set(spk.icons.keys()) if spk.icons else set()
-    written_icon_paths = []
-    for stale_size in set(existing_icons) - new_sizes:
-        del version.icons[stale_size]
-
-    if spk.icons:
-        version_path = os.path.join(
-            current_app.config["DATA_PATH"], package.name, str(version.version)
-        )
-        os.makedirs(version_path, exist_ok=True)
-        try:
-            for size, icon_stream in spk.icons.items():
-                icon_stream.seek(0)
-                icon_path = os.path.join(
-                    package.name, str(version.version), f"icon_{size}.png"
+        for key, value in info.items():
+            if key.startswith("description_"):
+                language_code = key.split("_", 1)[1]
+                language = Language.find(language_code)
+                if language is None:
+                    raise ValueError(
+                        f"Unknown INFO description language: {language_code}"
+                    )
+                version.descriptions[language.code] = Description(
+                    language=language, description=value
                 )
-                icon = version.icons.get(size)
-                if icon is None:
-                    icon = Icon(path=icon_path, size=size)
-                    version.icons[size] = icon
-                else:
-                    icon.path = icon_path
-                icon.save(icon_stream)
-                written_icon_paths.append(
-                    os.path.join(current_app.config["DATA_PATH"], icon_path)
-                )
-        except Exception:
-            # Clean up any icon files written in this call before re-raising,
-            # so a failed resync does not leave orphaned files on disk.
-            for path in written_icon_paths:
-                try:
-                    os.remove(path)
-                except OSError:
-                    pass
-            raise
 
-    # -- Build-level fields --------------------------------------------------
+        # Icon files are written to disk here. If anything raises after this point
+        # the caller's session rollback will undo the DB changes but the files will
+        # remain on disk — see docstring note above.
+        existing_icons = dict(version.icons)
+        new_sizes = set(spk.icons.keys()) if spk.icons else set()
+        written_icon_paths = []
+        for stale_size in set(existing_icons) - new_sizes:
+            del version.icons[stale_size]
 
-    build.architectures = resolve_architectures(session, info.get("arch"))
-    build.firmware_min = resolve_firmware(
-        session, info.get("firmware") or info.get("os_min_ver")
-    )
+        if spk.icons:
+            version_path = os.path.join(
+                current_app.config["DATA_PATH"], package.name, str(version.version)
+            )
+            os.makedirs(version_path, exist_ok=True)
+            try:
+                for size, icon_stream in spk.icons.items():
+                    icon_stream.seek(0)
+                    icon_path = os.path.join(
+                        package.name, str(version.version), f"icon_{size}.png"
+                    )
+                    icon = version.icons.get(size)
+                    if icon is None:
+                        icon = Icon(path=icon_path, size=size)
+                        version.icons[size] = icon
+                    else:
+                        icon.path = icon_path
+                    icon.save(icon_stream)
+                    written_icon_paths.append(
+                        os.path.join(current_app.config["DATA_PATH"], icon_path)
+                    )
+            except Exception:
+                # Clean up any icon files written in this call before re-raising,
+                # so a failed resync does not leave orphaned files on disk.
+                for path in written_icon_paths:
+                    try:
+                        os.remove(path)
+                    except OSError:
+                        pass
+                raise
 
-    firmware_max_value = info.get("os_max_ver")
-    firmware_max = resolve_firmware(session, firmware_max_value, allow_none=True)
-    if firmware_max and firmware_max.build < build.firmware_min.build:
-        raise ValueError(
-            "Maximum firmware must be greater than or equal to minimum firmware"
+        # -- Build-level fields --------------------------------------------------
+
+        build.architectures = resolve_architectures(session, info.get("arch"))
+        build.firmware_min = resolve_firmware(
+            session, info.get("firmware") or info.get("os_min_ver")
         )
-    build.firmware_max = firmware_max
 
-    build.checksum = info.get("checksum")
-    build.md5 = md5_hash
+        firmware_max_value = info.get("os_max_ver")
+        firmware_max = resolve_firmware(session, firmware_max_value, allow_none=True)
+        if firmware_max and firmware_max.build < build.firmware_min.build:
+            raise ValueError(
+                "Maximum firmware must be greater than or equal to minimum firmware"
+            )
+        build.firmware_max = firmware_max
 
-    manifest = build.buildmanifest
-    if manifest is None:
-        manifest = BuildManifest()
-        build.buildmanifest = manifest
+        build.checksum = info.get("checksum")
+        build.md5 = md5_hash
 
-    manifest.dependencies = info.get("install_dep_packages")
-    manifest.conf_dependencies = spk.conf_dependencies
-    manifest.conflicts = info.get("install_conflict_packages")
-    manifest.conf_conflicts = spk.conf_conflicts
-    manifest.conf_privilege = spk.conf_privilege
-    manifest.conf_resource = spk.conf_resource
+        manifest = build.buildmanifest
+        if manifest is None:
+            manifest = BuildManifest()
+            build.buildmanifest = manifest
 
-    session.flush()
+        manifest.dependencies = info.get("install_dep_packages")
+        manifest.conf_dependencies = spk.conf_dependencies
+        manifest.conflicts = info.get("install_conflict_packages")
+        manifest.conf_conflicts = spk.conf_conflicts
+        manifest.conf_privilege = spk.conf_privilege
+        manifest.conf_resource = spk.conf_resource
+
+        session.flush()
 
 
 def populate_db():

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -42,6 +42,7 @@ from ..models import (
     Version,
 )
 from ..utils import SPK, apply_info_from_spk, extract_version_metadata
+from .nas import clear_catalog_cache
 from .tasks import resync_build_file, resync_build_metadata
 
 # ---------------------------------------------------------------------------
@@ -382,9 +383,11 @@ class UserView(ModelView):
 
     def after_model_change(self, form, model, is_created):
         cache.delete("packages_versions")
+        clear_catalog_cache()
 
     def after_model_delete(self, model):
         cache.delete("packages_versions")
+        clear_catalog_cache()
 
     @action("activate", "Activate", "Are you sure you want to activate selected users?")
     def action_activate(self, ids):
@@ -579,9 +582,11 @@ class PackageView(ModelView):
 
     def after_model_change(self, form, model, is_created):
         cache.delete("packages_versions")
+        clear_catalog_cache()
 
     def after_model_delete(self, model):
         cache.delete("packages_versions")
+        clear_catalog_cache()
 
     can_view_details = True
     details_template = "admin/package_detail.html"
@@ -814,6 +819,7 @@ class VersionView(SignResyncMixin, ModelView):
                     build.active = True
             db.session.commit()
             cache.delete("packages_versions")
+            clear_catalog_cache()
             flash(
                 "Builds on version were successfully activated."
                 if len(versions) == 1
@@ -842,6 +848,7 @@ class VersionView(SignResyncMixin, ModelView):
                     build.active = False
             db.session.commit()
             cache.delete("packages_versions")
+            clear_catalog_cache()
             flash(
                 "Builds on version were successfully deactivated."
                 if len(versions) == 1
@@ -972,9 +979,11 @@ class BuildView(SignResyncMixin, ModelView):
 
     def after_model_change(self, form, model, is_created):
         cache.delete("packages_versions")
+        clear_catalog_cache()
 
     def after_model_delete(self, model):
         cache.delete("packages_versions")
+        clear_catalog_cache()
 
     @action(
         "activate", "Activate", "Are you sure you want to activate selected builds?"
@@ -986,6 +995,7 @@ class BuildView(SignResyncMixin, ModelView):
                 build.active = True
             db.session.commit()
             cache.delete("packages_versions")
+            clear_catalog_cache()
             flash(
                 "Build was successfully activated."
                 if len(builds) == 1
@@ -1008,6 +1018,7 @@ class BuildView(SignResyncMixin, ModelView):
                 build.active = False
             db.session.commit()
             cache.delete("packages_versions")
+            clear_catalog_cache()
             flash(
                 "Build was successfully deactivated."
                 if len(builds) == 1

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -232,6 +232,16 @@ def build_package_entry(b, language, arch, build):
     return entry
 
 
+def clear_catalog_cache():
+    """Invalidate all memoized NAS catalog cache entries.
+
+    Called by admin actions and background tasks whenever build metadata
+    or activation state changes, so Synology devices see fresh data
+    without waiting for the memoize timeout to expire.
+    """
+    cache.delete_memoized(get_catalog)
+
+
 @nas.route("/", methods=["POST", "GET"])
 def catalog():
     if (

--- a/spkrepo/views/tasks.py
+++ b/spkrepo/views/tasks.py
@@ -7,6 +7,7 @@ from flask import current_app
 from ..ext import cache, celery, db
 from ..models import Build
 from ..utils import SPK, apply_info_from_spk, extract_version_metadata
+from .nas import clear_catalog_cache
 
 
 @celery.task(bind=True, max_retries=3, default_retry_delay=10, queue="resync")
@@ -47,6 +48,7 @@ def resync_build_metadata(self, build_id, build_label):
             apply_info_from_spk(db.session, build, spk, md5)
             db.session.commit()
             cache.delete("packages_versions")
+            clear_catalog_cache()
 
         return {"status": "ok", "build_id": build_id, "label": build_label}
 
@@ -85,6 +87,7 @@ def resync_build_file(self, build_id, build_label):
         build.size = build.calculate_size()
         db.session.commit()
         cache.delete("packages_versions")
+        clear_catalog_cache()
         return {"status": "ok", "build_id": build_id, "label": build_label}
 
     except (ValueError, FileNotFoundError) as exc:


### PR DESCRIPTION
## Problems

### UniqueViolation on resync of existing metadata
When resyncing builds that already have displaynames or descriptions in the
database, the Celery worker raised an `IntegrityError`:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique
constraint "displayname_pkey"
DETAIL: Key (version_id, language_id)=(1829, 1) already exists.
```

`apply_info_from_spk` clears and rebuilds `version.displaynames` and
`version.descriptions` in sequence. When new `DisplayName` objects are
added after the clear, SQLAlchemy marks them as pending. Accessing
`version.descriptions` (a lazy-loaded relationship) then triggers an
autoflush of those pending objects before the old records are deleted,
causing the constraint violation. The task would retry 3 times and return
an error, leaving metadata unchanged.

### Stale NAS catalog after admin actions
`get_catalog` in `nas.py` is cached with `@cache.memoize(timeout=600)`.
Admin actions and background tasks that changed build state or metadata
called `cache.delete("packages_versions")` to invalidate the frontend
package list, but never called `cache.delete_memoized(get_catalog)`.
Synology devices could therefore receive stale catalog data for up to
10 minutes after any activation, deactivation, sign, unsign, or resync.

## Fixes

### `spkrepo/utils.py`
Wrap the entire body of `apply_info_from_spk` in `with session.no_autoflush`
to prevent SQLAlchemy flushing mid-function. The explicit `session.flush()`
at the end of the function still fires after all clears and inserts are
correctly staged. This fix applies to both the resync path (Celery) and the
upload path (API).

### `spkrepo/views/nas.py`
Add `clear_catalog_cache()` helper that calls
`cache.delete_memoized(get_catalog)`, keeping cache invalidation logic owned
by the module that defines the cache.

### `spkrepo/views/admin.py` and `spkrepo/views/tasks.py`
Call `clear_catalog_cache()` alongside every existing
`cache.delete("packages_versions")` — 10 call sites in `admin.py` and 2
in `tasks.py`.

## Impact

- Resync now completes successfully for packages with existing metadata
- Synology devices see updated catalog data immediately after any admin
  action rather than waiting up to 10 minutes for the memoize timeout