### PR TITLE
Move changelog and descriptions from version to build

### DIFF
--- a/migrations/versions/c63ff65c708a_move_changelog_and_description_to_build.py
+++ b/migrations/versions/c63ff65c708a_move_changelog_and_description_to_build.py
@@ -1,0 +1,95 @@
+"""Move changelog and description from version to build
+
+Revision ID: c63ff65c708a
+Revises: 23bbd5c74cd0
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c63ff65c708a"
+down_revision: Union[str, Sequence[str], None] = "23bbd5c74cd0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("build", sa.Column("changelog", sa.UnicodeText(), nullable=True))
+
+    op.create_table(
+        "build_description",
+        sa.Column("build_id", sa.Integer(), nullable=False),
+        sa.Column("language_id", sa.Integer(), nullable=False),
+        sa.Column("description", sa.UnicodeText(), nullable=False),
+        sa.ForeignKeyConstraint(["build_id"], ["build.id"]),
+        sa.ForeignKeyConstraint(["language_id"], ["language.id"]),
+        sa.PrimaryKeyConstraint("build_id", "language_id"),
+    )
+
+    op.execute(
+        """
+        UPDATE build
+        SET changelog = version.changelog
+        FROM version
+        WHERE build.version_id = version.id
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO build_description (build_id, language_id, description)
+        SELECT b.id, d.language_id, d.description
+        FROM build b
+        JOIN description d ON d.version_id = b.version_id
+        """
+    )
+
+    op.drop_column("version", "changelog")
+
+    op.drop_table("description")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "description",
+        sa.Column("version_id", sa.Integer(), nullable=False),
+        sa.Column("language_id", sa.Integer(), nullable=False),
+        sa.Column("description", sa.UnicodeText(), nullable=False),
+        sa.ForeignKeyConstraint(["version_id"], ["version.id"]),
+        sa.ForeignKeyConstraint(["language_id"], ["language.id"]),
+        sa.PrimaryKeyConstraint("version_id", "language_id"),
+    )
+
+    op.execute(
+        """
+        INSERT INTO description (version_id, language_id, description)
+        SELECT DISTINCT ON (b.version_id, bd.language_id)
+               b.version_id, bd.language_id, bd.description
+        FROM build_description bd
+        JOIN build b ON b.id = bd.build_id
+        """
+    )
+
+    op.drop_table("build_description")
+
+    op.add_column("version", sa.Column("changelog", sa.UnicodeText(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE version
+        SET changelog = sub.changelog
+        FROM (
+            SELECT DISTINCT ON (version_id) version_id, changelog
+            FROM build
+            WHERE changelog IS NOT NULL
+        ) sub
+        WHERE version.id = sub.version_id
+        """
+    )
+
+    op.drop_column("build", "changelog")

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -314,11 +314,11 @@ class DisplayName(db.Model):
         return f"<{self.__class__.__name__} {self.language.name}>"
 
 
-class Description(db.Model):
-    __tablename__ = "description"
+class BuildDescription(db.Model):
+    __tablename__ = "build_description"
 
     # Columns
-    version_id = db.Column(db.Integer, db.ForeignKey("version.id"), nullable=False)
+    build_id = db.Column(db.Integer, db.ForeignKey("build.id"), nullable=False)
     language_id = db.Column(db.Integer, db.ForeignKey("language.id"), nullable=False)
     description = db.Column(db.UnicodeText, nullable=False)
 
@@ -326,7 +326,7 @@ class Description(db.Model):
     language = db.relationship("Language")
 
     # Constraints
-    __table_args__ = (db.PrimaryKeyConstraint(version_id, language_id),)
+    __table_args__ = (db.PrimaryKeyConstraint(build_id, language_id),)
 
     def __str__(self):
         return self.description
@@ -408,6 +408,7 @@ class Build(db.Model):
     firmware_max_id = db.Column(db.Integer, db.ForeignKey("firmware.id"), index=True)
     publisher_user_id = db.Column(db.Integer, db.ForeignKey("user.id"), index=True)
     checksum = db.Column(db.Unicode(32))
+    changelog = db.Column(db.UnicodeText)
     path = db.Column(db.Unicode(2048))
     md5 = db.Column(db.Unicode(32))
     size = db.Column(db.Integer)
@@ -447,6 +448,11 @@ class Build(db.Model):
         back_populates="build",
         cascade="all, delete-orphan",
         uselist=False,
+    )
+    descriptions = db.relationship(
+        "BuildDescription",
+        cascade="all, delete-orphan",
+        collection_class=attribute_mapped_collection("language.code"),
     )
 
     @classmethod
@@ -539,7 +545,6 @@ class Version(db.Model):
     )
     version = db.Column(db.Integer, nullable=False, index=True)
     upstream_version = db.Column(db.Unicode(20), nullable=False)
-    changelog = db.Column(db.UnicodeText)
     report_url = db.Column(db.Unicode(255))
     distributor = db.Column(db.Unicode(50))
     distributor_url = db.Column(db.Unicode(255))
@@ -558,11 +563,6 @@ class Version(db.Model):
     )
     displaynames = db.relationship(
         "DisplayName",
-        cascade="all, delete-orphan",
-        collection_class=attribute_mapped_collection("language.code"),
-    )
-    descriptions = db.relationship(
-        "Description",
         cascade="all, delete-orphan",
         collection_class=attribute_mapped_collection("language.code"),
     )

--- a/spkrepo/templates/frontend/package.html
+++ b/spkrepo/templates/frontend/package.html
@@ -10,7 +10,7 @@
       <h1>{{ package.versions[-1].displaynames['enu'].displayname }}
         <small class="text-muted">v{{ package.versions[-1].version_string }}</small>
       </h1>
-      <p>{{ package.versions[-1].descriptions['enu'].description }}</p>
+      <p>{{ package.versions[-1].builds[0].descriptions['enu'].description }}</p>
       <div class="package-screenshots">
         {% for screenshot in package.screenshots %}
         <img class="package-screenshot" src="{{ url_for('nas.data', path=screenshot.path) }}"/>&nbsp;
@@ -19,7 +19,7 @@
       {% for version in package.versions|reverse %}
       <dl>
         <dt>Version {{ version.version_string | safe }}{% if version.report_url %} <span class="badge badge-danger">beta</span>{% endif %}</dt>
-        <dd>{{ version.changelog | safe }}</dd>
+        <dd>{{ version.builds[0].changelog | safe }}</dd>
         <dt>Date</dt>
         <dd>{{ version.insert_date.replace(microsecond=0) }}</dd>
         <dt>Architectures</dt>

--- a/spkrepo/templates/frontend/packages.html
+++ b/spkrepo/templates/frontend/packages.html
@@ -17,7 +17,7 @@
             <small class="text-muted">v{{ version.version_string }}</small>
           </h5>
           <div class="ellipsis package-description">
-            <p>{{ version.descriptions['enu'].description }}</p>
+            <p>{{ version.builds[0].descriptions['enu'].description }}</p>
           </div>
         </div>
       </div>

--- a/spkrepo/tests/common.py
+++ b/spkrepo/tests/common.py
@@ -28,8 +28,8 @@ from spkrepo.ext import db
 from spkrepo.models import (
     Architecture,
     Build,
+    BuildDescription,
     BuildManifest,
-    Description,
     DisplayName,
     DownloadStat,
     Firmware,
@@ -126,10 +126,10 @@ class DisplayNameFactory(SQLAlchemyModelFactory):
     displayname = factory.LazyAttribute(lambda x: " ".join(fake.words(nb=2)).title())
 
 
-class DescriptionFactory(SQLAlchemyModelFactory):
+class BuildDescriptionFactory(SQLAlchemyModelFactory):
     class Meta:
         sqlalchemy_session = db.session
-        model = Description
+        model = BuildDescription
 
     language = factory.LazyAttribute(lambda x: Language.find("enu"))
     description = factory.LazyAttribute(lambda x: " ".join(fake.sentences(nb=5)))
@@ -176,7 +176,6 @@ class VersionFactory(SQLAlchemyModelFactory):
             f"{fake.random_int(0, 5)}.{fake.random_int(0, 10)}.{fake.random_int(0, 15)}"
         )
     )
-    changelog = factory.LazyAttribute(lambda x: fake.sentence())
     report_url = factory.LazyAttribute(lambda x: fake.url())
     distributor = factory.LazyAttribute(lambda x: fake.name())
     distributor_url = factory.LazyAttribute(lambda x: fake.url())
@@ -197,14 +196,6 @@ class VersionFactory(SQLAlchemyModelFactory):
                 displayname = self.package.name.replace("_", " ").title()
                 self.displaynames["enu"] = DisplayNameFactory.simple_generate(
                     create, language=Language.find("enu"), displayname=displayname
-                )
-
-    @factory.post_generation
-    def add_description(self, create, extracted, **kwargs):
-        if extracted is None or extracted:
-            if "enu" not in self.descriptions:
-                self.descriptions["enu"] = DescriptionFactory.simple_generate(
-                    create, language=Language.find("enu")
                 )
 
     @factory.post_generation
@@ -241,6 +232,7 @@ class BuildFactory(SQLAlchemyModelFactory):
     version = factory.SubFactory(VersionFactory)
     firmware_min = factory.LazyAttribute(lambda x: random.choice(Firmware.query.all()))
     firmware_max = None
+    changelog = factory.LazyAttribute(lambda x: fake.sentence())
     architectures = factory.LazyAttribute(
         lambda x: [
             random.choice(
@@ -283,6 +275,14 @@ class BuildFactory(SQLAlchemyModelFactory):
 
         manifest = BuildManifest(**manifest_kwargs)
         self.buildmanifest = manifest
+
+    @factory.post_generation
+    def add_description(self, create, extracted, **kwargs):
+        if extracted is None or extracted:
+            if "enu" not in self.descriptions:
+                self.descriptions["enu"] = BuildDescriptionFactory.simple_generate(
+                    create, language=Language.find("enu")
+                )
 
     @factory.post_generation
     def create_spk(self, create, extracted, **kwargs):
@@ -427,13 +427,13 @@ def create_info(build):
             Architecture.to_syno.get(a.code, a.code) for a in build.architectures
         ),
         "displayname": build.version.displaynames["enu"].displayname,
-        "description": build.version.descriptions["enu"].description,
+        "description": build.descriptions["enu"].description,
         "firmware": build.firmware_min.firmware_string,
     }
     if build.firmware_max:
         info["os_max_ver"] = build.firmware_max.firmware_string
-    if build.version.changelog:
-        info["changelog"] = build.version.changelog
+    if build.changelog:
+        info["changelog"] = build.changelog
     if build.version.report_url:
         info["report_url"] = build.version.report_url
     if build.version.distributor:
@@ -457,7 +457,7 @@ def create_info(build):
         info["startable"] = "yes" if build.version.startable else "no"
     for language, displayname in build.version.displaynames.items():
         info[f"displayname_{language}"] = displayname.displayname
-    for language, description in build.version.descriptions.items():
+    for language, description in build.descriptions.items():
         info[f"description_{language}"] = description.description
     if build.buildmanifest and any(
         getattr(build.buildmanifest, attr) is not None

--- a/spkrepo/tests/test_admin.py
+++ b/spkrepo/tests/test_admin.py
@@ -272,7 +272,7 @@ class VersionTestCase(BaseTestCase):
 
         version = build.version
         original_display = version.displaynames["enu"].displayname
-        original_description = version.descriptions["enu"].description
+        original_description = build.descriptions["enu"].description
         original_services = sorted(
             service.code for service in version.service_dependencies
         )
@@ -280,7 +280,7 @@ class VersionTestCase(BaseTestCase):
         original_license = version.license
 
         version.displaynames["enu"].displayname = "Changed"
-        version.descriptions["enu"].description = "Changed"
+        build.descriptions["enu"].description = "Changed"
         version.service_dependencies = []
         version.upstream_version = "0.0.0"
         version.license = None
@@ -301,13 +301,14 @@ class VersionTestCase(BaseTestCase):
                 self.assertIn("queued", response.data.decode())
 
         db.session.expire_all()
-        refreshed_version = db.session.get(Build, build.id).version
+        refreshed_build = db.session.get(Build, build.id)
+        refreshed_version = refreshed_build.version
 
         self.assertEqual(
             refreshed_version.displaynames["enu"].displayname, original_display
         )
         self.assertEqual(
-            refreshed_version.descriptions["enu"].description, original_description
+            refreshed_build.descriptions["enu"].description, original_description
         )
         self.assertEqual(
             sorted(service.code for service in refreshed_version.service_dependencies),

--- a/spkrepo/tests/test_api.py
+++ b/spkrepo/tests/test_api.py
@@ -48,7 +48,7 @@ class PackagesTestCase(BaseTestCase):
         self.assertEqual(
             inserted_build.version.upstream_version, build.version.upstream_version
         )
-        self.assertEqual(inserted_build.version.changelog, build.version.changelog)
+        self.assertEqual(inserted_build.changelog, build.changelog)
         self.assertEqual(inserted_build.version.report_url, build.version.report_url)
         self.assertEqual(inserted_build.version.distributor, build.version.distributor)
         self.assertEqual(
@@ -75,11 +75,11 @@ class PackagesTestCase(BaseTestCase):
         self.assertDictEqual(
             {
                 language: description.description
-                for language, description in inserted_build.version.descriptions.items()
+                for language, description in inserted_build.descriptions.items()
             },
             {
                 language: description.description
-                for language, description in build.version.descriptions.items()
+                for language, description in build.descriptions.items()
             },
         )
         self.assertEqual(
@@ -665,13 +665,15 @@ class PackagesTestCase(BaseTestCase):
         self.assert422(response)
         self.assertIn("displaynames", response.data.decode())
 
-    def test_post_existing_version_mismatched_changelog_rejected(self):
-        # A second build with a different changelog must be rejected with 422.
+    def test_post_existing_version_different_changelog_allowed(self):
+        # A second build with a different changelog must be accepted since
+        # changelog is now per-build.
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
         db.session.commit()
 
         build = BuildFactory.build(
-            architectures=[Architecture.find("88f628x")],
+            version__upstream_version="1.0.0",
+            architectures=[Architecture.find("88f6281", syno=True)],
         )
         with create_spk(build) as spk:
             self.assert201(
@@ -682,23 +684,61 @@ class PackagesTestCase(BaseTestCase):
                 )
             )
 
-        persisted_version = Build.query.one().version
-        existing_changelog = persisted_version.changelog or ""
+        persisted_build = Build.query.one()
+        existing_changelog = persisted_build.changelog or ""
 
         new_build = BuildFactory.build(
-            version=persisted_version,
-            architectures=[Architecture.find("cedarview")],
+            version=build.version,
+            architectures=[Architecture.find("cedarview", syno=True)],
         )
         info = create_info(new_build)
         info["changelog"] = existing_changelog + " MODIFIED"
         with create_spk(new_build, info=info) as spk:
-            response = self.client.post(
-                url_for("api.packages"),
-                headers=authorization_header(user),
-                data=spk.read(),
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
             )
-        self.assert422(response)
-        self.assertIn("changelog", response.data.decode())
+
+    def test_post_existing_version_different_description_allowed(self):
+        # A second build with a different description must be accepted since
+        # descriptions are now per-build.
+        user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
+        db.session.commit()
+
+        build = BuildFactory.build(
+            version__upstream_version="1.0.0",
+            architectures=[Architecture.find("88f6281", syno=True)],
+        )
+        with create_spk(build) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
+
+        persisted_build = Build.query.one()
+        existing_description = persisted_build.descriptions["enu"].description
+
+        new_build = BuildFactory.build(
+            version=build.version,
+            architectures=[Architecture.find("cedarview", syno=True)],
+        )
+        info = create_info(new_build)
+        info["description"] = existing_description + " MODIFIED"
+        info["description_enu"] = existing_description + " MODIFIED"
+        with create_spk(new_build, info=info) as spk:
+            self.assert201(
+                self.client.post(
+                    url_for("api.packages"),
+                    headers=authorization_header(user),
+                    data=spk.read(),
+                )
+            )
 
     def test_post_existing_version_metadata_mismatch_does_not_persist(self):
         # A rejected upload must not partially modify the DB.

--- a/spkrepo/tests/test_frontend.py
+++ b/spkrepo/tests/test_frontend.py
@@ -79,7 +79,7 @@ class PackageTestCase(BaseTestCase):
             response_data,
         )
         self.assertIn(
-            build.version.descriptions["enu"].description,
+            build.descriptions["enu"].description,
             response_data,
         )
         self.assertNotIn("beta", response_data)
@@ -104,7 +104,7 @@ class PackageTestCase(BaseTestCase):
             response_data,
         )
         self.assertIn(
-            build.version.descriptions["enu"].description,
+            build.descriptions["enu"].description,
             response_data,
         )
         self.assertNotIn("beta", response_data)
@@ -128,7 +128,7 @@ class PackageTestCase(BaseTestCase):
             response_data,
         )
         self.assertIn(
-            build.version.descriptions["enu"].description,
+            build.descriptions["enu"].description,
             response_data,
         )
         self.assertIn("beta", response_data)
@@ -152,7 +152,7 @@ class PackageTestCase(BaseTestCase):
             response_data,
         )
         self.assertIn(
-            build.version.descriptions["enu"].description,
+            build.descriptions["enu"].description,
             response_data,
         )
         self.assertIn("beta", response_data)

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -12,6 +12,7 @@ from spkrepo.tests.common import (
     BuildFactory,
     DownloadStatFactory,
     PackageFactory,
+    VersionFactory,
 )
 
 
@@ -28,7 +29,7 @@ class CatalogTestCase(BaseTestCase):
         )
         self.assertEqual(
             entry["desc"],
-            build.version.descriptions[data.get("language", "enu")].description,
+            build.descriptions[data.get("language", "enu")].description,
         )
         self.assertGreaterEqual(len(entry["thumbnail"]), 1)
         self.assertEqual(
@@ -102,8 +103,8 @@ class CatalogTestCase(BaseTestCase):
             self.assertNotIn("beta", entry)
 
         # changelog
-        if build.version.changelog:
-            self.assertEqual(entry["changelog"], build.version.changelog)
+        if build.changelog:
+            self.assertEqual(entry["changelog"], build.changelog)
         else:
             self.assertNotIn("changelog", entry)
 
@@ -297,7 +298,7 @@ class CatalogTestCase(BaseTestCase):
         build = BuildFactory(
             active=True,
             version__report_url=None,
-            version__changelog=None,
+            changelog=None,
             version__distributor=None,
             version__distributor_url=None,
             version__maintainer=None,
@@ -625,3 +626,56 @@ class CatalogTestCase(BaseTestCase):
         self.assertEqual(entry["report_url"], build.version.report_url)
         self.assertIn("beta", entry)
         self.assertTrue(entry["beta"])
+
+    def test_catalog_returns_per_build_fields(self):
+        version = VersionFactory(report_url=None)
+        db.session.commit()
+
+        build_a = BuildFactory.create(
+            version=version,
+            active=True,
+            changelog="changelog_A",
+            architectures=[Architecture.find("88f6281", syno=True)],
+            firmware_min=Firmware.find(1594),
+            buildmanifest={"dependencies": "dep_A", "conflicts": "con_A"},
+        )
+        build_a.descriptions["enu"].description = "Desc A"
+
+        build_b = BuildFactory.create(
+            version=version,
+            active=True,
+            changelog="changelog_B",
+            architectures=[Architecture.find("cedarview", syno=True)],
+            firmware_min=Firmware.find(23739),
+            buildmanifest={"dependencies": "dep_B", "conflicts": "con_B"},
+        )
+        build_b.descriptions["enu"].description = "Desc B"
+        db.session.commit()
+
+        # Query matching build_a
+        data_a = dict(arch="88f6281", build="1594", language="enu")
+        response_a = self.client.post(url_for("nas.catalog"), data=data_a)
+        self.assert200(response_a)
+        catalog_a = json.loads(response_a.data.decode())
+        packages_a = catalog_a["packages"] if isinstance(catalog_a, dict) else catalog_a
+        self.assertEqual(len(packages_a), 1)
+        self.assertEqual(packages_a[0]["changelog"], "changelog_A")
+        self.assertEqual(packages_a[0]["desc"], "Desc A")
+        self.assertEqual(packages_a[0]["deppkgs"], "dep_A")
+        self.assertEqual(packages_a[0]["conflictpkgs"], "con_A")
+
+        # Query matching build_b
+        data_b = dict(arch="cedarview", build="23739", language="enu")
+        response_b = self.client.post(url_for("nas.catalog"), data=data_b)
+        self.assert200(response_b)
+        catalog_b = json.loads(response_b.data.decode())
+        packages_b = catalog_b["packages"] if isinstance(catalog_b, dict) else catalog_b
+        self.assertEqual(len(packages_b), 1)
+        self.assertEqual(packages_b[0]["changelog"], "changelog_B")
+        self.assertEqual(packages_b[0]["desc"], "Desc B")
+        self.assertEqual(packages_b[0]["deppkgs"], "dep_B")
+        self.assertEqual(packages_b[0]["conflictpkgs"], "con_B")
+
+        # Build-level auto-generated fields (md5, link) should differ per build
+        self.assertNotEqual(packages_a[0]["md5"], packages_b[0]["md5"])
+        self.assertNotEqual(packages_a[0]["link"], packages_b[0]["link"])

--- a/spkrepo/tests/test_utils.py
+++ b/spkrepo/tests/test_utils.py
@@ -57,12 +57,10 @@ class SPKParseTestCase(BaseTestCase):
             {Architecture.from_syno.get(a, a) for a in spk.info["arch"].split()},
             {a.code for a in build.architectures},
         )
-        self.assertEqual(build.version.changelog, spk.info["changelog"])
+        self.assertEqual(build.changelog, spk.info["changelog"])
+        self.assertEqual(build.descriptions["enu"].description, spk.info["description"])
         self.assertEqual(
-            build.version.descriptions["enu"].description, spk.info["description"]
-        )
-        self.assertEqual(
-            build.version.descriptions["enu"].description, spk.info["description_enu"]
+            build.descriptions["enu"].description, spk.info["description_enu"]
         )
         self.assertEqual(
             build.version.displaynames["enu"].displayname, spk.info["displayname"]
@@ -403,19 +401,6 @@ class ExtractVersionMetadataTestCase(BaseTestCase):
             build.version.displaynames["enu"].displayname,
         )
 
-    def test_descriptions_keyed_by_language_code(self):
-        # INFO key "description" must map to "enu", not the raw key name.
-        build = BuildFactory.build()
-        with create_spk(build) as f:
-            spk = SPK(f)
-        meta = extract_version_metadata(spk)
-        self.assertIn("enu", meta["descriptions"])
-        self.assertNotIn("description", meta["descriptions"])
-        self.assertEqual(
-            meta["descriptions"]["enu"],
-            build.version.descriptions["enu"].description,
-        )
-
     def test_startable_defaults_true(self):
         build = BuildFactory.build(version__startable=None)
         with create_spk(build) as f:
@@ -492,19 +477,6 @@ class AssertVersionMetadataMatchesDBTestCase(BaseTestCase):
             assert_version_metadata_matches_db(build.version, spk)
         self.assertIn("displaynames", str(cm.exception))
 
-    def test_mismatched_description_raises(self):
-        build = BuildFactory()
-        db.session.commit()
-        existing = build.version.descriptions["enu"].description
-        info = create_info(build)
-        info["description"] = existing + " MODIFIED"
-        info["description_enu"] = existing + " MODIFIED"
-        with create_spk(build, info=info) as f:
-            spk = SPK(f)
-        with self.assertRaises(ValueError) as cm:
-            assert_version_metadata_matches_db(build.version, spk)
-        self.assertIn("descriptions", str(cm.exception))
-
     def test_mismatched_upstream_version_raises(self):
         build = BuildFactory(version__upstream_version="1.0.0")
         db.session.commit()
@@ -515,18 +487,6 @@ class AssertVersionMetadataMatchesDBTestCase(BaseTestCase):
         with self.assertRaises(ValueError) as cm:
             assert_version_metadata_matches_db(build.version, spk)
         self.assertIn("upstream_version", str(cm.exception))
-
-    def test_mismatched_changelog_raises(self):
-        build = BuildFactory()
-        db.session.commit()
-        existing = build.version.changelog or ""
-        info = create_info(build)
-        info["changelog"] = existing + " MODIFIED"
-        with create_spk(build, info=info) as f:
-            spk = SPK(f)
-        with self.assertRaises(ValueError) as cm:
-            assert_version_metadata_matches_db(build.version, spk)
-        self.assertIn("changelog", str(cm.exception))
 
     def test_mismatched_service_dependencies_raises(self):
         build = BuildFactory(version__service_dependencies=[])
@@ -544,18 +504,17 @@ class AssertVersionMetadataMatchesDBTestCase(BaseTestCase):
         build = BuildFactory()
         db.session.commit()
         existing_displayname = build.version.displaynames["enu"].displayname
-        existing_changelog = build.version.changelog or ""
         info = create_info(build)
         info["displayname"] = existing_displayname + " MODIFIED"
         info["displayname_enu"] = existing_displayname + " MODIFIED"
-        info["changelog"] = existing_changelog + " MODIFIED"
+        info["version"] = f"9.9.9-{build.version.version}"
         with create_spk(build, info=info) as f:
             spk = SPK(f)
         with self.assertRaises(ValueError) as cm:
             assert_version_metadata_matches_db(build.version, spk)
         error = str(cm.exception)
         self.assertIn("displaynames", error)
-        self.assertIn("changelog", error)
+        self.assertIn("upstream_version", error)
 
 
 class PopulateDBTestCase(BaseTestCase):

--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -18,8 +18,8 @@ from .exceptions import SPKParseError, SPKSignError
 from .ext import db
 from .models import (
     Architecture,
+    BuildDescription,
     BuildManifest,
-    Description,
     DisplayName,
     Firmware,
     Icon,
@@ -460,19 +460,10 @@ def extract_version_metadata(spk):
     if "displayname" in info:
         displaynames["enu"] = info["displayname"]
 
-    # Same normalisation for descriptions.
-    descriptions = {}
-    for k, v in info.items():
-        if k.startswith("description_"):
-            descriptions[k.split("_", 1)[1]] = v
-    if "description" in info:
-        descriptions["enu"] = info["description"]
-
     return {
         "upstream_version": (
             version_match.group("upstream_version") if version_match else None
         ),
-        "changelog": info.get("changelog"),
         "report_url": info.get("report_url"),
         "distributor": info.get("distributor"),
         "distributor_url": info.get("distributor_url"),
@@ -488,7 +479,6 @@ def extract_version_metadata(spk):
             else set()
         ),
         "displaynames": displaynames,
-        "descriptions": descriptions,
     }
 
 
@@ -508,7 +498,6 @@ def assert_version_metadata_matches_db(version, spk):
 
     simple_fields = (
         "upstream_version",
-        "changelog",
         "report_url",
         "distributor",
         "distributor_url",
@@ -540,13 +529,6 @@ def assert_version_metadata_matches_db(version, spk):
         mismatches.append(
             f"displaynames: SPK has {incoming['displaynames']}, "
             f"DB has {existing_displaynames}"
-        )
-
-    existing_descriptions = {k: v.description for k, v in version.descriptions.items()}
-    if incoming["descriptions"] != existing_descriptions:
-        mismatches.append(
-            f"descriptions: SPK has {incoming['descriptions']}, "
-            f"DB has {existing_descriptions}"
         )
 
     if mismatches:
@@ -602,7 +584,7 @@ def apply_info_from_spk(session, build, spk, md5_hash):
 
         version = build.version
         version.upstream_version = version_match.group("upstream_version")
-        version.changelog = info.get("changelog")
+        build.changelog = info.get("changelog")
         version.report_url = info.get("report_url")
         version.distributor = info.get("distributor")
         version.distributor_url = info.get("distributor_url")
@@ -642,13 +624,13 @@ def apply_info_from_spk(session, build, spk, md5_hash):
                     language=language, displayname=value
                 )
 
-        version.descriptions.clear()
+        build.descriptions.clear()
         default_description = info.get("description")
         if default_description:
             language = Language.find("enu")
             if language is None:
                 raise ValueError("Language 'enu' is not defined")
-            version.descriptions[language.code] = Description(
+            build.descriptions[language.code] = BuildDescription(
                 language=language, description=default_description
             )
         for key, value in info.items():
@@ -659,7 +641,7 @@ def apply_info_from_spk(session, build, spk, md5_hash):
                     raise ValueError(
                         f"Unknown INFO description language: {language_code}"
                     )
-                version.descriptions[language.code] = Description(
+                build.descriptions[language.code] = BuildDescription(
                     language=language, description=value
                 )
 

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -947,6 +947,7 @@ class BuildView(SignResyncMixin, ModelView):
         "size": lambda v, c, m, p: (
             f"{m.size / 1024 / 1024:.1f} MB" if m.size else None
         ),
+        "active": _bool_formatter,
     }
     column_default_sort = (Build.insert_date, True)
 

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -15,8 +15,8 @@ from ..exceptions import SPKParseError, SPKSignError
 from ..ext import db
 from ..models import (
     Build,
+    BuildDescription,
     BuildManifest,
-    Description,
     DisplayName,
     Icon,
     Language,
@@ -209,7 +209,6 @@ class Packages(Resource):
                 package=package,
                 upstream_version=match.group("upstream_version"),
                 version=int(match.group("version")),
-                changelog=spk.info.get("changelog"),
                 report_url=spk.info.get("report_url"),
                 distributor=spk.info.get("distributor"),
                 distributor_url=spk.info.get("distributor_url"),
@@ -234,17 +233,6 @@ class Packages(Resource):
                         abort(422, message="Unknown INFO displayname language")
                     version.displaynames[language.code] = DisplayName(
                         language=language, displayname=value
-                    )
-                elif key == "description":
-                    version.descriptions["enu"] = Description(
-                        description=value, language=Language.find("enu")
-                    )
-                elif key.startswith("description_"):
-                    language = Language.find(key.split("_", 1)[1])
-                    if not language:
-                        abort(422, message="Unknown INFO description language")
-                    version.descriptions[language.code] = Description(
-                        language=language, description=value
                     )
 
             # Icon
@@ -295,7 +283,21 @@ class Packages(Resource):
             publisher=current_user,
             path=os.path.join(package.name, str(version.version), build_filename),
             checksum=spk.info.get("checksum"),
+            changelog=spk.info.get("changelog"),
         )
+
+        for key, value in spk.info.items():
+            if key == "description":
+                build.descriptions["enu"] = BuildDescription(
+                    description=value, language=Language.find("enu")
+                )
+            elif key.startswith("description_"):
+                language = Language.find(key.split("_", 1)[1])
+                if not language:
+                    abort(422, message="Unknown INFO description language")
+                build.descriptions[language.code] = BuildDescription(
+                    language=language, description=value
+                )
 
         build.buildmanifest = BuildManifest(
             dependencies=spk.info.get("install_dep_packages"),

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -9,7 +9,14 @@ from wtforms import StringField, SubmitField, ValidationError
 from wtforms.validators import InputRequired, Length
 
 from ..ext import cache, db
-from ..models import Build, Description, DisplayName, Package, Version, user_datastore
+from ..models import (
+    Build,
+    BuildDescription,
+    DisplayName,
+    Package,
+    Version,
+    user_datastore,
+)
 
 frontend = Blueprint("frontend", __name__)
 
@@ -70,7 +77,9 @@ def packages():
                 db.joinedload(Version.package),
                 db.joinedload(Version.icons),
                 db.joinedload(Version.displaynames).joinedload(DisplayName.language),
-                db.joinedload(Version.descriptions).joinedload(Description.language),
+                db.joinedload(Version.builds)
+                .joinedload(Build.descriptions)
+                .joinedload(BuildDescription.language),
             )
             .join(
                 latest_version,
@@ -93,7 +102,9 @@ def package(name):
         .options(
             db.joinedload(Package.versions).joinedload(Version.icons),
             db.joinedload(Package.versions).joinedload(Version.displaynames),
-            db.joinedload(Package.versions).joinedload(Version.descriptions),
+            db.joinedload(Package.versions)
+            .joinedload(Version.builds)
+            .joinedload(Build.descriptions),
         )
         .first()
     )

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -16,7 +16,7 @@ from ..ext import cache, db
 from ..models import (
     Architecture,
     Build,
-    Description,
+    BuildDescription,
     DisplayName,
     Firmware,
     Language,
@@ -127,7 +127,7 @@ def get_catalog(arch, build, major, language, beta):
             db.joinedload(Build.version)
             .joinedload(Version.displaynames)
             .joinedload(DisplayName.language),
-            db.joinedload(Build.version, Version.descriptions, Description.language),
+            db.joinedload(Build.descriptions).joinedload(BuildDescription.language),
             db.joinedload(Build.version, Version.package, Package.screenshots),
             db.joinedload(Build.buildmanifest),
         )
@@ -179,9 +179,7 @@ def build_package_entry(b, language, arch, build):
         "dname": b.version.displaynames.get(
             language, b.version.displaynames["enu"]
         ).displayname,
-        "desc": b.version.descriptions.get(
-            language, b.version.descriptions["enu"]
-        ).description,
+        "desc": b.descriptions.get(language, b.descriptions["enu"]).description,
         "link": url_for(
             ".data",
             path=b.path,
@@ -218,7 +216,7 @@ def build_package_entry(b, language, arch, build):
         entry["report_url"] = b.version.report_url
         entry["beta"] = True
 
-    _set_if_truthy(entry, "changelog", b.version.changelog)
+    _set_if_truthy(entry, "changelog", b.changelog)
     _set_if_truthy(entry, "distributor", b.version.distributor)
     _set_if_truthy(entry, "distributor_url", b.version.distributor_url)
     _set_if_truthy(entry, "maintainer", b.version.maintainer)


### PR DESCRIPTION
## Summary

Allow each build within a version to have its own changelog and
localized descriptions, rather than sharing them at the version level.

## Changes

### Model
- Add `BuildDescription` model (`build_description` table) keyed by
  `(build_id, language_id)` — mirrors the existing `DisplayName` pattern
- Add `changelog` column to `Build`
- Remove `changelog` column and `descriptions` relationship from `Version`
- Remove the now-unused `Description` model and `description` table

### SPK ingestion (`utils.py`)
- `extract_version_metadata()` — no longer extracts changelog/descriptions
  (they're per-build, not per-version)
- `assert_version_metadata_matches_db()` — no longer validates
  changelog/description consistency across sibling builds
- `apply_info_from_spk()` — writes changelog/descriptions to build
  instead of version

### API upload (`views/api.py`)
- Version creation no longer sets changelog or descriptions
- Build creation sets changelog directly and populates build-level
  descriptions

### NAS catalog (`views/nas.py`)
- Reads `b.changelog` and `b.descriptions` instead of
  `b.version.changelog` / `b.version.descriptions`
- Eager loading updated to `Build.descriptions`

### Frontend
- Eager loads descriptions through builds
- Templates reference `builds[0].descriptions['enu'].description`
  and `builds[0].changelog`

### Admin
- Add `active` bool formatter to Build detail view (was rendering as
  raw text)

### Tests
- Update all assertions to reference build-level fields
- Add `test_post_existing_version_different_changelog_allowed` and
  `test_post_existing_version_different_description_allowed`
- Add `test_catalog_returns_per_build_fields` — verifies NAS catalog
  returns different changelog, description, deppkgs, conflictpkgs, md5,
  and link per build under the same version
- Remove tests for the old version-level consistency checks (changelog,
  description)

### Migrations
- `c63ff65c708a` — create `build_description`, add `build.changelog`,
  migrate data, drop old `description` table and `version.changelog`