### PR TITLE
Minor fixes: API sets signed, activate commits before upload, clean up build list

### DIFF
--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -1218,7 +1218,6 @@ class BuildView(SignResyncMixin, ModelView):
             builds = get_query_for_ids(self.get_query(), self.model, ids).all()
             not_signed = []
             activated = []
-            upload_tasks = []
             storage_ok = storage_service.storage_configured()
             for build in builds:
                 if not build.signed and not _detect_and_fix_signed(build):
@@ -1226,14 +1225,18 @@ class BuildView(SignResyncMixin, ModelView):
                     continue
                 build.active = True
                 activated.append(build)
-                if build.storage == "local" and storage_ok:
-                    result = upload_to_storage.delay(build.id, str(build))
-                    upload_tasks.append(
-                        {"id": result.id, "type": "upload", "label": str(build)}
-                    )
             db.session.commit()
             cache.delete("packages_versions")
             clear_catalog_cache()
+
+            upload_tasks = []
+            if storage_ok:
+                for build in activated:
+                    if build.storage == "local":
+                        result = upload_to_storage.delay(build.id, str(build))
+                        upload_tasks.append(
+                            {"id": result.id, "type": "upload", "label": str(build)}
+                        )
             if upload_tasks:
                 _store_task_tasks(upload_tasks)
             if not_signed:

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -1134,7 +1134,6 @@ class BuildView(SignResyncMixin, ModelView):
         "firmware_min.version",
         "publisher.username",
         "storage",
-        "signed",
         "active",
     )
     column_sortable_list = (
@@ -1144,7 +1143,6 @@ class BuildView(SignResyncMixin, ModelView):
         ("publisher", "publisher.username"),
         ("insert_date", "insert_date"),
         ("storage", "storage"),
-        ("signed", "signed"),
         ("active", "active"),
     )
     column_formatters = {
@@ -1155,7 +1153,6 @@ class BuildView(SignResyncMixin, ModelView):
             f"{m.size / 1024 / 1024:.1f} MB" if m.size else None
         ),
         "storage": _storage_formatter,
-        "signed": _bool_formatter,
         "active": _bool_formatter,
     }
     column_formatters_detail = {

--- a/spkrepo/views/api.py
+++ b/spkrepo/views/api.py
@@ -319,6 +319,8 @@ class Packages(Resource):
                 )
             except SPKSignError as e:
                 abort(500, message="Failed to sign package", details=str(e))
+        if spk.signature is not None:
+            build.signed = True
 
         # save files
         try:


### PR DESCRIPTION
This is a follow-on for #207 to address some minor bugs.

## Fixes

### API upload not setting `build.signed`
The API signs the SPK file after processing but never updated the `build.signed` column. This caused the `upload_to_storage` task to reject newly uploaded packages with `"Build is not signed"`. Fixed by setting `build.signed = True` after the signing step.

### Activate queuing upload before DB commit
The Activate action queued Celery upload tasks before calling `db.session.commit()`. The task read `signed=False` from the database (the old value) and failed. Fixed by splitting into two passes: activate + commit first, then queue upload tasks.

### Remove stale `signed` filter from Build list view
The `signed` column was previously removed from the Build list display, but the column filter, sortable entry, and list formatter were left behind. Cleaned up.
