### PR TITLE
Add download analytics to architecture, firmware, and dashboard

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -530,6 +530,63 @@ class Build(db.Model):
         return f"<{self.__class__.__name__} {self.path}>"
 
 
+Architecture.download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .join(Build, Build.id == DownloadStat.build_id)
+    .join(build_architecture, build_architecture.c.build_id == Build.id)
+    .where(build_architecture.c.architecture_id == Architecture.id)
+    .correlate(Architecture)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+Architecture.recent_download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .join(Build, Build.id == DownloadStat.build_id)
+    .join(build_architecture, build_architecture.c.build_id == Build.id)
+    .where(
+        db.and_(
+            build_architecture.c.architecture_id == Architecture.id,
+            DownloadStat.date >= _days_ago(90),
+        )
+    )
+    .correlate(Architecture)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+Firmware.download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .join(Build, Build.id == DownloadStat.build_id)
+    .where(
+        db.or_(
+            Build.firmware_min_id == Firmware.id,
+            Build.firmware_max_id == Firmware.id,
+        )
+    )
+    .correlate(Firmware)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+Firmware.recent_download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .join(Build, Build.id == DownloadStat.build_id)
+    .where(
+        db.and_(
+            db.or_(
+                Build.firmware_min_id == Firmware.id,
+                Build.firmware_max_id == Firmware.id,
+            ),
+            DownloadStat.date >= _days_ago(90),
+        )
+    )
+    .correlate(Firmware)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+
 class BuildManifest(db.Model):
     __tablename__ = "buildmanifest"
 

--- a/spkrepo/templates/admin/index.html
+++ b/spkrepo/templates/admin/index.html
@@ -16,10 +16,10 @@
   </div>
 
   {# Stat tiles #}
-  {% set col_width = 'col-md-3 col-sm-6' if unconfirmed_user_count is not none else 'col-md-4 col-sm-6' %}
+  {% set tile_cols = 'col-md-3 col-sm-6' if unconfirmed_user_count is none else 'col-md col-sm-6' %}
   <div class="row mb-2">
 
-    <div class="{{ col_width }} mb-3">
+    <div class="{{ tile_cols }} mb-3">
       <div class="card border-info h-100">
         <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Packages</div>
         <div class="card-body bg-light d-flex align-items-center justify-content-center">
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <div class="{{ col_width }} mb-3">
+    <div class="{{ tile_cols }} mb-3">
       <div class="card border-info h-100">
         <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Builds</div>
         <div class="card-body bg-light d-flex align-items-center justify-content-center">
@@ -37,7 +37,7 @@
       </div>
     </div>
 
-    <div class="{{ col_width }} mb-3">
+    <div class="{{ tile_cols }} mb-3">
       <div class="card {% if inactive_build_count > 0 %}border-warning{% else %}border-info{% endif %} h-100">
         <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Inactive Builds</div>
         <div class="card-body bg-light d-flex align-items-center justify-content-center">
@@ -46,8 +46,17 @@
       </div>
     </div>
 
+    <div class="{{ tile_cols }} mb-3">
+      <div class="card border-info h-100">
+        <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Downloads (90d)</div>
+        <div class="card-body bg-light d-flex align-items-center justify-content-center">
+          <span style="font-size: 2em;">{{ "{:,}".format(recent_downloads) }}</span>
+        </div>
+      </div>
+    </div>
+
     {% if unconfirmed_user_count is not none %}
-    <div class="{{ col_width }} mb-3">
+    <div class="{{ tile_cols }} mb-3">
       <div class="card {% if unconfirmed_user_count > 0 %}border-warning{% else %}border-info{% endif %} h-100">
         <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Unconfirmed Users</div>
         <div class="card-body bg-light d-flex align-items-center justify-content-center">

--- a/spkrepo/templates/admin/package_detail.html
+++ b/spkrepo/templates/admin/package_detail.html
@@ -34,7 +34,7 @@
     <table class="table table-hover table-bordered searchable">
       {% for c, name in details_columns %}
         <tr>
-          <td><b>{% if c == 'recent_download_count' %}Recent Downloads (90d){% else %}{{ name }}{% endif %}</b></td>
+          <td><b>{% if c == 'recent_download_count' %}Downloads (90d){% else %}{{ name }}{% endif %}</b></td>
           <td>
             {% if c == 'arch_breakdown' %}
               {% if arch_breakdown %}
@@ -47,6 +47,28 @@
                       <td style="width: 100%; padding-right: 10px">
                         <div style="background: #e9ecef; border-radius: 3px; height: 14px">
                           <div style="background: #5b9bd5; border-radius: 3px; height: 14px; width: {{ pct | round(1) }}%"></div>
+                        </div>
+                      </td>
+                      <td style="white-space: nowrap; color: #666; font-size: 0.9em">
+                        {{ "{:,}".format(count) }} ({{ pct | round | int }}%)
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </table>
+              {% else %}
+                <span class="text-muted">No downloads in the last 90 days</span>
+              {% endif %}
+            {% elif c == 'firmware_breakdown' %}
+              {% if firmware_breakdown %}
+                <table style="width: 100%; max-width: 380px; border: none; border-spacing: 0">
+                  {% for label, count, pct in firmware_breakdown %}
+                    <tr>
+                      <td style="white-space: nowrap; padding-right: 10px; font-family: monospace; width: 1%">
+                        {{ label }}
+                      </td>
+                      <td style="width: 100%; padding-right: 10px">
+                        <div style="background: #e9ecef; border-radius: 3px; height: 14px">
+                          <div style="background: #e67e22; border-radius: 3px; height: 14px; width: {{ pct | round(1) }}%"></div>
                         </div>
                       </td>
                       <td style="white-space: nowrap; color: #666; font-size: 0.9em">

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -42,6 +42,7 @@ from ..models import (
     Service,
     User,
     Version,
+    _days_ago,
 )
 from ..utils import (
     SPK,
@@ -613,6 +614,25 @@ class ArchitectureView(ModelView):
 
     form_excluded_columns = "builds"
 
+    column_list = ("code", "download_count", "recent_download_count")
+    column_labels = {
+        "download_count": "Downloads",
+        "recent_download_count": "Downloads (90d)",
+    }
+    column_sortable_list = (
+        ("code", "code"),
+        ("download_count", "download_count"),
+        ("recent_download_count", "recent_download_count"),
+    )
+    column_formatters = {
+        "download_count": lambda v, c, m, p: (
+            f"{m.download_count:,}" if m.download_count else "0"
+        ),
+        "recent_download_count": lambda v, c, m, p: (
+            f"{m.recent_download_count:,}" if m.recent_download_count else "0"
+        ),
+    }
+
 
 class FirmwareView(ModelView):
     """View for :class:`~spkrepo.models.Firmware`"""
@@ -625,6 +645,33 @@ class FirmwareView(ModelView):
 
     can_edit = False
     can_delete = False
+
+    column_list = (
+        "version",
+        "build",
+        "type",
+        "download_count",
+        "recent_download_count",
+    )
+    column_labels = {
+        "download_count": "Downloads",
+        "recent_download_count": "Downloads (90d)",
+    }
+    column_sortable_list = (
+        ("version", "version"),
+        ("build", "build"),
+        ("type", "type"),
+        ("download_count", "download_count"),
+        ("recent_download_count", "recent_download_count"),
+    )
+    column_formatters = {
+        "download_count": lambda v, c, m, p: (
+            f"{m.download_count:,}" if m.download_count else "0"
+        ),
+        "recent_download_count": lambda v, c, m, p: (
+            f"{m.recent_download_count:,}" if m.recent_download_count else "0"
+        ),
+    }
 
     form_columns = ("version", "build", "type")
     form_args = {
@@ -765,6 +812,7 @@ class PackageView(ModelView):
     @expose("/details/")
     def details_view(self):
         self._template_args["arch_breakdown"] = self._get_arch_breakdown()
+        self._template_args["firmware_breakdown"] = self._get_firmware_breakdown()
         return super().details_view()
 
     def _get_arch_breakdown(self):
@@ -792,6 +840,36 @@ class PackageView(ModelView):
             return None
         grand_total = sum(total for _, total in rows)
         return [(code, total, total / grand_total * 100) for code, total in rows]
+
+    def _get_firmware_breakdown(self):
+        pkg_id = request.args.get("id", type=int)
+        if not pkg_id:
+            return None
+        cutoff = date.today() - timedelta(days=90)
+        rows = db.session.execute(
+            db.select(
+                Firmware.version,
+                Firmware.build,
+                db.func.sum(DownloadStat.count).label("total"),
+            )
+            .join(Firmware, Firmware.build == DownloadStat.firmware_build)
+            .where(
+                db.and_(
+                    DownloadStat.package_id == pkg_id,
+                    DownloadStat.date >= cutoff,
+                )
+            )
+            .group_by(Firmware.version, Firmware.build)
+            .order_by(db.desc("total"))
+            .limit(3)
+        ).all()
+        if not rows:
+            return None
+        grand_total = sum(total for _, _, total in rows)
+        return [
+            (f"{ver}-{build}", total, total / grand_total * 100)
+            for ver, build, total in rows
+        ]
 
     column_list = (
         "name",
@@ -830,10 +908,11 @@ class PackageView(ModelView):
     }
     column_labels = {
         "download_count": "Downloads",
-        "recent_download_count": "Recent Downloads",
+        "recent_download_count": "Downloads (90d)",
         "last_download_date": "Last Download",
         "author.username": "Author",
         "arch_breakdown": "Top Architectures (90d)",
+        "firmware_breakdown": "Top Firmwares (90d)",
     }
     column_filters = ("name", "author.username")
     column_details_list = (
@@ -845,6 +924,7 @@ class PackageView(ModelView):
         "recent_download_count",
         "last_download_date",
         "arch_breakdown",
+        "firmware_breakdown",
     )
 
     form_columns = ("name", "author", "maintainers")
@@ -922,7 +1002,7 @@ class VersionView(SignResyncMixin, ModelView):
         "upgrade_wizard": "Upgrade Wizard",
         "total_size": "Total Size",
         "download_count": "Downloads",
-        "recent_download_count": "Recent Downloads (90d)",
+        "recent_download_count": "Downloads (90d)",
     }
     column_filters = (
         "package.name",
@@ -1337,6 +1417,25 @@ class IndexView(AdminIndexView):
                 .all()
             )
 
+        if is_privileged:
+            recent_downloads = db.session.execute(
+                db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0)).where(
+                    DownloadStat.date >= _days_ago(90)
+                )
+            ).scalar()
+        else:
+            recent_downloads = db.session.execute(
+                db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+                .join(Package, Package.id == DownloadStat.package_id)
+                .join(Package.maintainers)
+                .where(
+                    db.and_(
+                        User.id == current_user.id,
+                        DownloadStat.date >= _days_ago(90),
+                    )
+                )
+            ).scalar()
+
         return self.render(
             "admin/index.html",
             package_count=package_count,
@@ -1348,6 +1447,7 @@ class IndexView(AdminIndexView):
                 else None
             ),
             recent_versions=recent_versions,
+            recent_downloads=recent_downloads,
         )
 
 


### PR DESCRIPTION
## Summary

Add download analytics to Architecture and Firmware list views, the
dashboard, and the Package detail page — all from existing DownloadStat
data with no schema changes.

## Changes

### Model
- Add `download_count` and `recent_download_count` column properties
  to Architecture (aggregated via build_architecture join)
- Add the same column properties to Firmware (aggregated via
  firmware_min_id / firmware_max_id)

### Admin Views
- Architecture list: new "Downloads" and "Downloads (90d)" columns
- Firmware list: same columns added alongside existing version/build/type
- Package detail: new "Top Firmwares (90d)" CSS bar chart (orange),
  mirroring the existing "Top Architectures (90d)" (blue)

### Dashboard
- New "Downloads (90d)" stat tile
- Downloads are scoped to maintained packages for non-admin users
- Bootstrap auto-layout keeps tile widths responsive regardless of
  how many tiles are visible
