### PR TITLE
Fix Architecture and Firmware download counts (double-counting through build joins)

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -532,9 +532,7 @@ class Build(db.Model):
 
 Architecture.download_count = db.column_property(
     db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
-    .join(Build, Build.id == DownloadStat.build_id)
-    .join(build_architecture, build_architecture.c.build_id == Build.id)
-    .where(build_architecture.c.architecture_id == Architecture.id)
+    .where(DownloadStat.architecture_id == Architecture.id)
     .correlate(Architecture)
     .scalar_subquery(),
     deferred=True,
@@ -542,11 +540,9 @@ Architecture.download_count = db.column_property(
 
 Architecture.recent_download_count = db.column_property(
     db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
-    .join(Build, Build.id == DownloadStat.build_id)
-    .join(build_architecture, build_architecture.c.build_id == Build.id)
     .where(
         db.and_(
-            build_architecture.c.architecture_id == Architecture.id,
+            DownloadStat.architecture_id == Architecture.id,
             DownloadStat.date >= _days_ago(90),
         )
     )
@@ -557,13 +553,7 @@ Architecture.recent_download_count = db.column_property(
 
 Firmware.download_count = db.column_property(
     db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
-    .join(Build, Build.id == DownloadStat.build_id)
-    .where(
-        db.or_(
-            Build.firmware_min_id == Firmware.id,
-            Build.firmware_max_id == Firmware.id,
-        )
-    )
+    .where(DownloadStat.firmware_build == Firmware.build)
     .correlate(Firmware)
     .scalar_subquery(),
     deferred=True,
@@ -571,13 +561,9 @@ Firmware.download_count = db.column_property(
 
 Firmware.recent_download_count = db.column_property(
     db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
-    .join(Build, Build.id == DownloadStat.build_id)
     .where(
         db.and_(
-            db.or_(
-                Build.firmware_min_id == Firmware.id,
-                Build.firmware_max_id == Firmware.id,
-            ),
+            DownloadStat.firmware_build == Firmware.build,
             DownloadStat.date >= _days_ago(90),
         )
     )

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -42,7 +42,6 @@ from ..models import (
     Service,
     User,
     Version,
-    _days_ago,
 )
 from ..utils import (
     SPK,
@@ -1417,10 +1416,11 @@ class IndexView(AdminIndexView):
                 .all()
             )
 
+        cutoff = date.today() - timedelta(days=90)
         if is_privileged:
             recent_downloads = db.session.execute(
                 db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0)).where(
-                    DownloadStat.date >= _days_ago(90)
+                    DownloadStat.date >= cutoff
                 )
             ).scalar()
         else:
@@ -1431,7 +1431,7 @@ class IndexView(AdminIndexView):
                 .where(
                     db.and_(
                         User.id == current_user.id,
-                        DownloadStat.date >= _days_ago(90),
+                        DownloadStat.date >= cutoff,
                     )
                 )
             ).scalar()


### PR DESCRIPTION
## Summary

Fix download count calculations for Architecture and Firmware views.
Both were using indirect joins through the Build table that double-counted
downloads. They now query DownloadStat directly, matching the correct
pattern used by Package and other views.

## Changes

### Firmware
- `Firmware.download_count` and `.recent_download_count` now query
  `download_stat.firmware_build` directly instead of joining through
  `Build.firmware_min_id / firmware_max_id`. The old approach counted
  the same download for both the minimum and maximum firmware of a
  build, inflating counts significantly (e.g. 30,546 → 2,267 for
  firmware 6.2-25556).

### Architecture
- `Architecture.download_count` and `.recent_download_count` now query
  `download_stat.architecture_id` directly instead of joining through
  `build_architecture → build`. The old approach counted the same
  download for every architecture a build supports, rather than the
  actual architecture of the downloading NAS.
