### PR TITLE
Fix resync sibling handling, stale sidecars, and related issues

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -651,6 +651,7 @@ class Version(db.Model):
         back_populates="version",
         cascade="all, delete-orphan",
         cascade_backrefs=False,
+        order_by="Build.id",
     )
 
     # Constraints

--- a/spkrepo/tests/test_object_storage_tasks.py
+++ b/spkrepo/tests/test_object_storage_tasks.py
@@ -40,7 +40,7 @@ class UploadToStorageTestCase(BaseTestCase):
         self.assertIn("not signed", result["error"])
 
     def test_skipped_when_sidecar_exists(self):
-        build = BuildFactory(signed=True)
+        build = BuildFactory(signed=True, storage="remote")
         db.session.commit()
         sidecar = os.path.join(current_app.config["DATA_PATH"], build.path + ".json")
         with io.open(sidecar, "w") as f:
@@ -48,6 +48,17 @@ class UploadToStorageTestCase(BaseTestCase):
         result = upload_to_storage(build.id, str(build))
         self.assertEqual(result["status"], "skipped")
         os.remove(sidecar)
+
+    def test_stale_sidecar_is_cleaned(self):
+        """Sidecar with storage=local should be removed and upload reprocessed."""
+        build = BuildFactory(signed=True)
+        db.session.commit()
+        sidecar = os.path.join(current_app.config["DATA_PATH"], build.path + ".json")
+        with io.open(sidecar, "w") as f:
+            f.write("{}")
+        result = upload_to_storage(build.id, str(build))
+        self.assertNotEqual(result["status"], "skipped")
+        self.assertFalse(os.path.exists(sidecar))
 
     def test_skipped_when_build_not_found(self):
         result = upload_to_storage(999999, "nonexistent")

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -44,12 +44,7 @@ from ..models import (
     Version,
     _days_ago,
 )
-from ..utils import (
-    SPK,
-    apply_info_from_spk,
-    apply_sidecar_to_db,
-    extract_version_metadata,
-)
+from ..utils import SPK
 from .nas import clear_catalog_cache
 from .tasks import (
     rehome_from_storage,
@@ -176,48 +171,6 @@ def _resync_build_file(build):
     else:
         build.md5 = build.calculate_md5()
         build.size = build.calculate_size()
-
-
-def _resync_build_metadata(session, build):
-    """Re-read build metadata from SPK file or sidecar and apply to DB.
-
-    When the file is in Object Storage (sidecar exists), reads metadata
-    from the sidecar. When local, parses the SPK archive and checks
-    consistency against siblings first.
-    """
-    if not build.path:
-        raise ValueError("Build has no file path")
-
-    data_path = current_app.config["DATA_PATH"]
-    sidecar_path = os.path.join(data_path, build.path + ".json")
-
-    if os.path.exists(sidecar_path):
-        with io.open(sidecar_path, "r", encoding="utf-8") as f:
-            sidecar = json.load(f)
-        apply_sidecar_to_db(session, build, sidecar)
-        return
-
-    file_path = os.path.join(data_path, build.path)
-    with io.open(file_path, "rb") as stream:
-        spk = SPK(stream)
-        incoming_meta = extract_version_metadata(spk)
-
-        for sibling in build.version.builds:
-            if sibling.id == build.id or not sibling.path:
-                continue
-            sibling_path = os.path.join(data_path, sibling.path)
-            with io.open(sibling_path, "rb") as s2:
-                sibling_meta = extract_version_metadata(SPK(s2))
-            if sibling_meta != incoming_meta:
-                raise ValueError(
-                    "Version-level metadata mismatch between "
-                    f"{os.path.basename(build.path)} and "
-                    f"{os.path.basename(sibling.path)} — resync aborted. "
-                    "Inspect the SPK files to resolve the inconsistency."
-                )
-
-        md5 = spk.calculate_md5()
-        apply_info_from_spk(session, build, spk, md5)
 
 
 # ---------------------------------------------------------------------------

--- a/spkrepo/views/tasks.py
+++ b/spkrepo/views/tasks.py
@@ -54,9 +54,19 @@ def resync_build_metadata(self, build_id, build_label):
             for sibling in build.version.builds:
                 if sibling.id == build.id or not sibling.path:
                     continue
-                sibling_path = os.path.join(data_path, sibling.path)
-                with io.open(sibling_path, "rb") as s2:
-                    sibling_meta = extract_version_metadata(SPK(s2))
+                sibling_spk_path = os.path.join(data_path, sibling.path)
+                sibling_sidecar_path = sibling_spk_path + ".json"
+                if os.path.exists(sibling_sidecar_path):
+                    with io.open(sibling_sidecar_path, "r", encoding="utf-8") as s2:
+                        sc = json.load(s2)
+                    sibling_meta = extract_version_metadata(
+                        type("_", (), {"info": sc["info"]})()
+                    )
+                elif os.path.exists(sibling_spk_path):
+                    with io.open(sibling_spk_path, "rb") as s2:
+                        sibling_meta = extract_version_metadata(SPK(s2))
+                else:
+                    continue
                 if sibling_meta != incoming_meta:
                     raise ValueError(
                         "Version-level metadata mismatch between "
@@ -177,13 +187,15 @@ def upload_to_storage(self, build_id, build_label):
         }
 
     if os.path.exists(sidecar_path):
-        return {
-            "status": "skipped",
-            "type": "upload",
-            "build_id": build_id,
-            "label": build_label,
-            "error": "Already uploaded (sidecar exists)",
-        }
+        if build.storage == "remote":
+            return {
+                "status": "skipped",
+                "type": "upload",
+                "build_id": build_id,
+                "label": build_label,
+                "error": "Already uploaded (sidecar exists)",
+            }
+        os.remove(sidecar_path)
 
     try:
         info = {}
@@ -260,6 +272,8 @@ def upload_to_storage(self, build_id, build_label):
                 "error": "Upload to Object Storage failed",
             }
 
+        build.md5 = sidecar["calculated"]["md5"]
+        build.size = sidecar["calculated"]["size"]
         build.storage = "remote"
         db.session.commit()
     except Exception as exc:
@@ -303,29 +317,43 @@ def rehome_from_storage(self, build_id, build_label):
     data_path = current_app.config["DATA_PATH"]
     local_path = os.path.join(data_path, build.path)
 
-    if not storage.download(build.path, local_path):
+    try:
+        if not storage.download(build.path, local_path):
+            return {
+                "status": "error",
+                "type": "rehome",
+                "build_id": build_id,
+                "label": build_label,
+                "error": "Download from Object Storage failed",
+            }
+
+        sidecar_path = local_path + ".json"
+        if os.path.exists(sidecar_path):
+            os.remove(sidecar_path)
+
+        storage.delete(build.path)
+        storage.purge_cdn("/" + build.path)
+
+        build.storage = "local"
+        db.session.commit()
+        cache.delete("packages_versions")
+        clear_catalog_cache()
         return {
-            "status": "error",
+            "status": "ok",
             "type": "rehome",
             "build_id": build_id,
             "label": build_label,
-            "error": "Download from Object Storage failed",
         }
 
-    sidecar_path = local_path + ".json"
-    if os.path.exists(sidecar_path):
-        os.remove(sidecar_path)
-
-    storage.delete(build.path)
-    storage.purge_cdn("/" + build.path)
-
-    build.storage = "local"
-    db.session.commit()
-    cache.delete("packages_versions")
-    clear_catalog_cache()
-    return {
-        "status": "ok",
-        "type": "rehome",
-        "build_id": build_id,
-        "label": build_label,
-    }
+    except Exception as exc:
+        db.session.rollback()
+        try:
+            raise self.retry(exc=exc)
+        except self.MaxRetriesExceededError:
+            return {
+                "status": "error",
+                "type": "rehome",
+                "build_id": build_id,
+                "label": build_label,
+                "error": str(exc),
+            }


### PR DESCRIPTION
## Summary

Fix several issues found during a codebase review: resync crashes on
remote siblings, stale sidecar recovery, missing md5/size updates,
unused dead code, and deterministic build ordering.

## Changes

### Resync sibling check (HIGH)
`resync_build_metadata` crashed with `FileNotFoundError` when a sibling
build was in Object Storage (no local `.spk`). Now reads sibling metadata
from sidecar if available, or skips if neither file nor sidecar exists.

### Stale sidecar recovery (MEDIUM)
If `upload_to_storage` crashed after writing the sidecar but before
committing `storage = "remote"`, the build was permanently stuck. Now
detects and cleans stale sidecars where `storage != "remote"`.

### md5/size not updated on upload (MEDIUM)
`upload_to_storage` calculated fresh md5, sha256, and size for the
sidecar but never wrote them back to the Build record. Fixed.

### rehome exception handling (LOW)
`rehome_from_storage` lacked try/except and Celery retry, unlike the
other storage tasks. Added.

### Dead code removal (LOW)
Removed unused `_resync_build_metadata` helper from `admin.py` (all
resync goes through the Celery task).

### Build ordering (LOW)
Added `order_by=Build.id` to `Version.builds` so frontend templates
accessing `version.builds[0]` get deterministic results.
