### PR TITLE
Add target firmware tracking to download stats

### DIFF
--- a/migrations/versions/23bbd5c74cd0_replace_download_with_download_stat.py
+++ b/migrations/versions/23bbd5c74cd0_replace_download_with_download_stat.py
@@ -10,7 +10,6 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "23bbd5c74cd0"
@@ -108,7 +107,7 @@ def downgrade() -> None:
         sa.Column(
             "user_agent", sa.VARCHAR(length=255), autoincrement=False, nullable=True
         ),
-        sa.Column("date", postgresql.TIMESTAMP(), autoincrement=False, nullable=False),
+        sa.Column("date", sa.DateTime(), autoincrement=False, nullable=False),
         sa.ForeignKeyConstraint(
             ["architecture_id"],
             ["architecture.id"],

--- a/migrations/versions/325d7d86f788_add_target_firmware_tracking_to_.py
+++ b/migrations/versions/325d7d86f788_add_target_firmware_tracking_to_.py
@@ -1,0 +1,67 @@
+"""add target firmware tracking to download stats
+
+Revision ID: 325d7d86f788
+Revises: 3fdb8480a9f5
+Create Date: 2026-06-14 10:43:33.209412
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "325d7d86f788"
+down_revision: Union[str, Sequence[str], None] = "3fdb8480a9f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "download_stat", sa.Column("target_firmware_build", sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        "download_stat",
+        sa.Column(
+            "target_noarch",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.drop_constraint(op.f("uq_download_stat"), "download_stat", type_="unique")
+    op.create_unique_constraint(
+        "uq_download_stat",
+        "download_stat",
+        [
+            "package_id",
+            "architecture_id",
+            "firmware_build",
+            "target_firmware_build",
+            "date",
+        ],
+    )
+    op.create_index(
+        op.f("ix_download_stat_target_firmware_build"),
+        "download_stat",
+        ["target_firmware_build"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        op.f("ix_download_stat_target_firmware_build"), table_name="download_stat"
+    )
+    op.drop_constraint("uq_download_stat", "download_stat", type_="unique")
+    op.create_unique_constraint(
+        op.f("uq_download_stat"),
+        "download_stat",
+        ["package_id", "architecture_id", "firmware_build", "date"],
+    )
+    op.drop_column("download_stat", "target_noarch")
+    op.drop_column("download_stat", "target_firmware_build")

--- a/migrations/versions/3fdb8480a9f5_add_storage_and_signed_columns_to_build.py
+++ b/migrations/versions/3fdb8480a9f5_add_storage_and_signed_columns_to_build.py
@@ -20,13 +20,11 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.execute("CREATE TYPE storage_location AS ENUM ('local', 'remote')")
-
     op.add_column(
         "build",
         sa.Column(
             "storage",
-            sa.Enum("local", "remote", name="storage_location", create_type=False),
+            sa.Enum("local", "remote", name="storage_location"),
             nullable=False,
             server_default="local",
         ),
@@ -41,4 +39,3 @@ def downgrade() -> None:
     """Downgrade schema."""
     op.drop_column("build", "signed")
     op.drop_column("build", "storage")
-    op.execute("DROP TYPE IF EXISTS storage_location")

--- a/migrations/versions/c63ff65c708a_move_changelog_and_description_to_build.py
+++ b/migrations/versions/c63ff65c708a_move_changelog_and_description_to_build.py
@@ -34,9 +34,9 @@ def upgrade() -> None:
     op.execute(
         """
         UPDATE build
-        SET changelog = version.changelog
-        FROM version
-        WHERE build.version_id = version.id
+        SET changelog = (
+            SELECT changelog FROM version WHERE version.id = build.version_id
+        )
         """
     )
 
@@ -68,10 +68,10 @@ def downgrade() -> None:
     op.execute(
         """
         INSERT INTO description (version_id, language_id, description)
-        SELECT DISTINCT ON (b.version_id, bd.language_id)
-               b.version_id, bd.language_id, bd.description
+        SELECT b.version_id, bd.language_id, MIN(bd.description) AS description
         FROM build_description bd
         JOIN build b ON b.id = bd.build_id
+        GROUP BY b.version_id, bd.language_id
         """
     )
 
@@ -82,13 +82,11 @@ def downgrade() -> None:
     op.execute(
         """
         UPDATE version
-        SET changelog = sub.changelog
-        FROM (
-            SELECT DISTINCT ON (version_id) version_id, changelog
-            FROM build
-            WHERE changelog IS NOT NULL
-        ) sub
-        WHERE version.id = sub.version_id
+        SET changelog = (
+            SELECT changelog FROM build
+            WHERE build.version_id = version.id AND changelog IS NOT NULL
+            LIMIT 1
+        )
         """
     )
 

--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -267,7 +267,6 @@ def ingest_logs():
 
     import boto3
     from botocore.exceptions import BotoCoreError, ClientError
-    from sqlalchemy.dialects.postgresql import insert as pg_insert
 
     from .models import Architecture, Build, DownloadStat, Version
 
@@ -308,7 +307,26 @@ def ingest_logs():
             record_date = datetime.fromisoformat(record["timestamp"]).date()
         except (KeyError, ValueError):
             record_date = date.today()
-        return package_name, version_number, arch_code, firmware_build, record_date
+
+        # Parse target info from the SPK filename
+        target_firmware_build = None
+        target_noarch = False
+        filename = path.rsplit("/", 1)[-1] if "/" in path else path
+        fm = re.search(r"\.f(\d+)\[([^\]]+)\]", filename)
+        if fm:
+            target_firmware_build = int(fm.group(1))
+            archs = fm.group(2).split("-")
+            target_noarch = "noarch" in archs
+
+        return (
+            package_name,
+            version_number,
+            arch_code,
+            firmware_build,
+            record_date,
+            target_firmware_build,
+            target_noarch,
+        )
 
     bucket = current_app.config["OBJECT_STORAGE_LOGS_BUCKET"]
     prefix = current_app.config.get("OBJECT_STORAGE_LOGS_PREFIX", "logs/")
@@ -334,10 +352,12 @@ def ingest_logs():
 
     logger.info("Processing %d log file(s).", len(objects))
 
-    build_cache = {}  # (package_name, version_number) -> (build_id, package_id) or None
+    # (pkg_name, ver, target_fw) -> (build_id, pkg_id) or None
+    build_cache = {}
     arch_cache = {}  # arch_code -> architecture_id or None
     counts = defaultdict(int)
     build_ids = {}  # agg_key -> build_id or None
+    target_noarchs = {}  # agg_key -> bool
     processed_keys = []
 
     skipped_no_arch = 0
@@ -365,25 +385,45 @@ def ingest_logs():
                 parsed = parse_download(record)
                 if parsed is None:
                     continue
-                package_name, version_number, arch_code, firmware_build, record_date = (
-                    parsed
-                )
+                (
+                    package_name,
+                    version_number,
+                    arch_code,
+                    firmware_build,
+                    record_date,
+                    target_firmware_build,
+                    target_noarch,
+                ) = parsed
 
                 if arch_code is None or firmware_build is None:
                     skipped_no_arch += 1
                     continue
 
-                cache_key = (package_name, version_number)
+                cache_key = (package_name, version_number, target_firmware_build)
                 if cache_key not in build_cache:
-                    build = (
+                    from .models import Firmware as FirmwareModel
+
+                    build_query = (
                         db.session.query(Build)
                         .join(Version)
                         .filter(
                             Version.version == version_number,
                             Version.package.has(name=package_name),
                         )
-                        .first()
                     )
+                    if target_firmware_build is not None:
+                        build_query = build_query.filter(
+                            Build.firmware_min.has(
+                                FirmwareModel.build <= target_firmware_build
+                            ),
+                            db.or_(
+                                Build.firmware_max_id.is_(None),
+                                Build.firmware_max.has(
+                                    FirmwareModel.build >= target_firmware_build
+                                ),
+                            ),
+                        )
+                    build = build_query.first()
                     if build:
                         build_cache[cache_key] = (build.id, build.version.package_id)
                     else:
@@ -404,13 +444,18 @@ def ingest_logs():
                     skipped_no_arch_id += 1
                     continue
 
-                agg_key = (package_id, architecture_id, firmware_build, record_date)
+                agg_key = (
+                    package_id,
+                    architecture_id,
+                    firmware_build,
+                    target_firmware_build,
+                    record_date,
+                )
                 counts[agg_key] += 1
+                target_noarchs[agg_key] = target_noarch
 
                 if agg_key not in build_ids:
                     build_ids[agg_key] = build_id
-                elif build_ids[agg_key] != build_id:
-                    build_ids[agg_key] = None
 
             processed_keys.append(key)
 
@@ -425,17 +470,36 @@ def ingest_logs():
                 "build_id": build_ids.get(agg_key),
                 "architecture_id": architecture_id,
                 "firmware_build": firmware_build,
+                "target_firmware_build": target_firmware_build,
+                "target_noarch": target_noarchs.get(agg_key, False),
                 "date": record_date,
                 "count": count,
             }
             for agg_key, count in counts.items()
-            for (package_id, architecture_id, firmware_build, record_date) in [agg_key]
+            for (
+                package_id,
+                architecture_id,
+                firmware_build,
+                target_firmware_build,
+                record_date,
+            ) in [agg_key]
         ]
         try:
-            stmt = pg_insert(DownloadStat).values(rows)
+            dialect = db.session.bind.dialect.name
+            if dialect == "postgresql":
+                from sqlalchemy.dialects.postgresql import insert as upsert_insert
+            elif dialect == "sqlite":
+                from sqlalchemy.dialects.sqlite import insert as upsert_insert
+            else:
+                raise RuntimeError(f"Upsert not supported for dialect: {dialect}")
+
+            stmt = upsert_insert(DownloadStat).values(rows)
             stmt = stmt.on_conflict_do_update(
                 constraint="uq_download_stat",
-                set_={"count": DownloadStat.count + stmt.excluded.count},
+                set_={
+                    "count": DownloadStat.count + stmt.excluded.count,
+                    "target_noarch": stmt.excluded.target_noarch,
+                },
             )
             db.session.execute(stmt)
             db.session.commit()

--- a/spkrepo/filters.py
+++ b/spkrepo/filters.py
@@ -22,7 +22,26 @@ def sort_fields(form, field_names=None):
     return fields
 
 
+def abbreviate_number(value):
+    """Abbreviate large numbers with K/M suffixes (e.g. 103897 -> 103.9K)."""
+    if value is None:
+        return "0"
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return str(value)
+    if abs(value) >= 1_000_000:
+        result = f"{value / 1_000_000:.1f}M"
+        return result.replace(".0M", "M")
+    if abs(value) >= 1_000:
+        result = f"{value / 1_000:.1f}K"
+        result = result.replace(".0K", "K")
+        return "1M" if result == "1000K" else result
+    return f"{value:,}"
+
+
 def register_filters(app):
     """Register all Jinja2 template filters on the given Flask app."""
     app.template_filter()(is_hidden_field)
     app.template_filter()(sort_fields)
+    app.template_filter()(abbreviate_number)

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -360,6 +360,8 @@ class DownloadStat(db.Model):
         db.Integer, db.ForeignKey("architecture.id"), nullable=False, index=True
     )
     firmware_build = db.Column(db.Integer, nullable=False, index=True)
+    target_firmware_build = db.Column(db.Integer, nullable=True, index=True)
+    target_noarch = db.Column(db.Boolean, nullable=False, default=False)
     date = db.Column(db.Date, nullable=False, index=True)
     count = db.Column(db.Integer, nullable=False, default=0)
 
@@ -369,6 +371,7 @@ class DownloadStat(db.Model):
             "package_id",
             "architecture_id",
             "firmware_build",
+            "target_firmware_build",
             "date",
             name="uq_download_stat",
         ),
@@ -551,6 +554,51 @@ Architecture.recent_download_count = db.column_property(
     deferred=True,
 )
 
+_noarch_id = (
+    db.select(Architecture.id).where(Architecture.code == "noarch").scalar_subquery()
+)
+
+Architecture.target_download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .where(
+        db.or_(
+            db.and_(
+                DownloadStat.target_noarch.is_(True),
+                Architecture.id == _noarch_id,
+            ),
+            db.and_(
+                DownloadStat.target_noarch.isnot(True),
+                DownloadStat.architecture_id == Architecture.id,
+            ),
+        )
+    )
+    .correlate(Architecture)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+Architecture.recent_target_download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .where(
+        db.and_(
+            db.or_(
+                db.and_(
+                    DownloadStat.target_noarch.is_(True),
+                    Architecture.id == _noarch_id,
+                ),
+                db.and_(
+                    DownloadStat.target_noarch.isnot(True),
+                    DownloadStat.architecture_id == Architecture.id,
+                ),
+            ),
+            DownloadStat.date >= _days_ago(90),
+        )
+    )
+    .correlate(Architecture)
+    .scalar_subquery(),
+    deferred=True,
+)
+
 Firmware.download_count = db.column_property(
     db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
     .where(DownloadStat.firmware_build == Firmware.build)
@@ -564,6 +612,27 @@ Firmware.recent_download_count = db.column_property(
     .where(
         db.and_(
             DownloadStat.firmware_build == Firmware.build,
+            DownloadStat.date >= _days_ago(90),
+        )
+    )
+    .correlate(Firmware)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+Firmware.target_download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .where(DownloadStat.target_firmware_build == Firmware.build)
+    .correlate(Firmware)
+    .scalar_subquery(),
+    deferred=True,
+)
+
+Firmware.recent_target_download_count = db.column_property(
+    db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
+    .where(
+        db.and_(
+            DownloadStat.target_firmware_build == Firmware.build,
             DownloadStat.date >= _days_ago(90),
         )
     )

--- a/spkrepo/templates/admin/index.html
+++ b/spkrepo/templates/admin/index.html
@@ -50,7 +50,7 @@
       <div class="card border-info h-100">
         <div class="card-header bg-secondary text-white" style="font-size: 0.85em;">Downloads (90d)</div>
         <div class="card-body bg-light d-flex align-items-center justify-content-center">
-          <span style="font-size: 2em;">{{ "{:,}".format(recent_downloads) }}</span>
+          <span style="font-size: 2em;">{{ recent_downloads | abbreviate_number }}</span>
         </div>
       </div>
     </div>

--- a/spkrepo/templates/admin/model/download_stats_list.html
+++ b/spkrepo/templates/admin/model/download_stats_list.html
@@ -1,0 +1,67 @@
+{% extends 'admin/model/list.html' %}
+
+{% block list_header scoped %}
+    {% if actions %}
+    <th class="list-checkbox-column" rowspan="2">
+        <input type="checkbox" name="rowtoggle" class="action-rowtoggle" title="{{ _gettext('Select all records') }}" />
+    </th>
+    {% endif %}
+    {% if admin_view.column_display_actions %}
+    <th class="" rowspan="2">&nbsp;</th>
+    {% endif %}
+
+    {% set download_cols = ['download_count', 'recent_download_count', 'target_download_count', 'recent_target_download_count'] %}
+
+    {% for c, name in list_columns %}
+    {% set column = loop.index0 %}
+    {% if c not in download_cols %}
+    <th class="column-header col-{{c | replace('.', '-') }}" rowspan="2">
+        {% if admin_view.is_sortable(c) %}
+            {% if sort_column == column %}
+                <a href="{{ sort_url(column, True) }}" title="{{ _gettext('Sort by %(name)s', name=name) }}">
+                    {{ name }}
+                    {% if sort_desc %}
+                    <span class="fa fa-chevron-up glyphicon glyphicon-chevron-up"></span>
+                    {% else %}
+                    <span class="fa fa-chevron-down glyphicon glyphicon-chevron-down"></span>
+                    {% endif %}
+                </a>
+            {% else %}
+                <a href="{{ sort_url(column) }}" title="{{ _gettext('Sort by %(name)s', name=name) }}">{{ name }}</a>
+            {% endif %}
+        {% else %}
+            {{ name }}
+        {% endif %}
+    </th>
+    {% endif %}
+    {% endfor %}
+
+    <th colspan="4" style="text-align:center; vertical-align:middle; border-bottom:none">
+        {{ _gettext('Download Counts') }}
+    </th>
+</tr>
+<tr>
+    {% for c, name in list_columns %}
+    {% set column = loop.index0 %}
+    {% if c in download_cols %}
+    <th class="column-header col-{{c | replace('.', '-') }}" style="border-top:none">
+        {% if admin_view.is_sortable(c) %}
+            {% if sort_column == column %}
+                <a href="{{ sort_url(column, True) }}" title="{{ _gettext('Sort by %(name)s', name=name) }}">
+                    {{ name }}
+                    {% if sort_desc %}
+                    <span class="fa fa-chevron-up glyphicon glyphicon-chevron-up"></span>
+                    {% else %}
+                    <span class="fa fa-chevron-down glyphicon glyphicon-chevron-down"></span>
+                    {% endif %}
+                </a>
+            {% else %}
+                <a href="{{ sort_url(column) }}" title="{{ _gettext('Sort by %(name)s', name=name) }}">{{ name }}</a>
+            {% endif %}
+        {% else %}
+            {{ name }}
+        {% endif %}
+    </th>
+    {% endif %}
+    {% endfor %}
+{% endblock %}

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -566,15 +566,27 @@ class ArchitectureView(ModelView):
 
     form_excluded_columns = "builds"
 
-    column_list = ("code", "download_count", "recent_download_count")
+    list_template = "admin/model/download_stats_list.html"
+
+    column_list = (
+        "code",
+        "download_count",
+        "recent_download_count",
+        "target_download_count",
+        "recent_target_download_count",
+    )
     column_labels = {
-        "download_count": "Downloads",
-        "recent_download_count": "Downloads (90d)",
+        "download_count": "By NAS",
+        "recent_download_count": "By NAS (90d)",
+        "target_download_count": "By Build",
+        "recent_target_download_count": "By Build (90d)",
     }
     column_sortable_list = (
         ("code", "code"),
         ("download_count", "download_count"),
         ("recent_download_count", "recent_download_count"),
+        ("target_download_count", "target_download_count"),
+        ("recent_target_download_count", "recent_target_download_count"),
     )
     column_formatters = {
         "download_count": lambda v, c, m, p: (
@@ -582,6 +594,14 @@ class ArchitectureView(ModelView):
         ),
         "recent_download_count": lambda v, c, m, p: (
             f"{m.recent_download_count:,}" if m.recent_download_count else "0"
+        ),
+        "target_download_count": lambda v, c, m, p: (
+            f"{m.target_download_count:,}" if m.target_download_count else "0"
+        ),
+        "recent_target_download_count": lambda v, c, m, p: (
+            f"{m.recent_target_download_count:,}"
+            if m.recent_target_download_count
+            else "0"
         ),
     }
 
@@ -598,16 +618,22 @@ class FirmwareView(ModelView):
     can_edit = False
     can_delete = False
 
+    list_template = "admin/model/download_stats_list.html"
+
     column_list = (
         "version",
         "build",
         "type",
         "download_count",
         "recent_download_count",
+        "target_download_count",
+        "recent_target_download_count",
     )
     column_labels = {
-        "download_count": "Downloads",
-        "recent_download_count": "Downloads (90d)",
+        "download_count": "By NAS",
+        "recent_download_count": "By NAS (90d)",
+        "target_download_count": "By Build",
+        "recent_target_download_count": "By Build (90d)",
     }
     column_sortable_list = (
         ("version", "version"),
@@ -615,6 +641,8 @@ class FirmwareView(ModelView):
         ("type", "type"),
         ("download_count", "download_count"),
         ("recent_download_count", "recent_download_count"),
+        ("target_download_count", "target_download_count"),
+        ("recent_target_download_count", "recent_target_download_count"),
     )
     column_formatters = {
         "download_count": lambda v, c, m, p: (
@@ -622,6 +650,14 @@ class FirmwareView(ModelView):
         ),
         "recent_download_count": lambda v, c, m, p: (
             f"{m.recent_download_count:,}" if m.recent_download_count else "0"
+        ),
+        "target_download_count": lambda v, c, m, p: (
+            f"{m.target_download_count:,}" if m.target_download_count else "0"
+        ),
+        "recent_target_download_count": lambda v, c, m, p: (
+            f"{m.recent_target_download_count:,}"
+            if m.recent_target_download_count
+            else "0"
         ),
     }
 


### PR DESCRIPTION
## Summary
Adds `target_firmware_build` and `target_noarch` columns to `download_stat`
for tracking which firmware/architecture SPK packages were built for, alongside
the existing NAS hardware firmware tracking.

## Changes

### Schema (Migration `325d7d86f788`)
- Add `target_firmware_build` (Integer, nullable) and `target_noarch` (Boolean)
  to `download_stat`
- Unique constraint `uq_download_stat` now includes `target_firmware_build` so
  different SPK target firmwares get separate rows
- Index on `target_firmware_build`

### Ingest (`cli.py`)
- Build lookup matches by target firmware range for correct `build_id`
- Aggregation key includes `target_firmware_build` to avoid bucket collisions
- Dialect-agnostic upsert (PostgreSQL + SQLite)

### Model properties
- **Architecture**: `target_download_count` / `recent_target_download_count` —
  computed from `target_noarch` (noarch → noarch arch, non-noarch → NAS arch)
- **Firmware**: `target_download_count` / `recent_target_download_count` —
  computed from `target_firmware_build`

### Admin UI
- Architecture and Firmware list views show merged "Download Counts" header
  with "By NAS" and "By Build" sub-columns
- Custom template `admin/model/download_stats_list.html`

### Migrations made portable
- `postgresql.TIMESTAMP()` -> `sa.DateTime()`
- Manual `CREATE/DROP TYPE ENUM` -> `sa.Enum()` (auto-managed)
- `UPDATE ... FROM` -> correlated subqueries
- `DISTINCT ON` -> `GROUP BY MIN()` / `LIMIT 1`
