### PR TITLE
Fix ingest dialect detection

### DIFF
--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -485,7 +485,7 @@ def ingest_logs():
             ) in [agg_key]
         ]
         try:
-            dialect = db.session.bind.dialect.name
+            dialect = db.engine.dialect.name
             if dialect == "postgresql":
                 from sqlalchemy.dialects.postgresql import insert as upsert_insert
             elif dialect == "sqlite":


### PR DESCRIPTION
This is a follow-on for #216 to address a minor bug.

## Fixes

`db.session.bind` is `None` on a fresh session — Flask-SQLAlchemy lazily
binds it on first query. The refactored dialect-agnostic upsert in
`ingest_logs` tried to read `db.session.bind.dialect.name` before any
query ran, causing `AttributeError`.

Fixed by using `db.engine.dialect.name` instead, which is always
available after app initialization.
