### PR TITLE
 Fix parse_download: URL-decode path before parsing SPK filename

### DIFF
--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import shutil
+import urllib.parse
 
 import click
 from flask import current_app
@@ -287,7 +288,7 @@ def ingest_logs():
 
     def parse_download(record):
         url = record.get("url", "")
-        path = url.split("?")[0]
+        path = urllib.parse.unquote(url.split("?")[0])
         match = re.match(r"^/([^/]+)/([^/]+)/", path)
         if not match:
             return None


### PR DESCRIPTION
This is a follow-on for #216 to address a minor bug.

## Fixes

CDN log URLs are URL-encoded (`%5B` for `[`, `%5D` for `]`). The regex
`\[([^\]]+)\]` used to extract the target firmware build and noarch
flag never matched, so `target_firmware_build` was always `None` and
`target_noarch` always `False` for every download.

Adding `urllib.parse.unquote(path)` before the regex fixes both
target firmware detection and noarch detection for all downloads