### PR TITLE
Fix build lookup: filter by architecture to prevent SRM build misattribution

### DIFF
--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -353,7 +353,7 @@ def ingest_logs():
 
     logger.info("Processing %d log file(s).", len(objects))
 
-    # (pkg_name, ver, target_fw) -> (build_id, pkg_id) or None
+    # (pkg_name, ver, arch, target_fw) -> (build_id, pkg_id) or None
     build_cache = {}
     arch_cache = {}  # arch_code -> architecture_id or None
     counts = defaultdict(int)
@@ -400,7 +400,12 @@ def ingest_logs():
                     skipped_no_arch += 1
                     continue
 
-                cache_key = (package_name, version_number, target_firmware_build)
+                cache_key = (
+                    package_name,
+                    version_number,
+                    arch_code,
+                    target_firmware_build,
+                )
                 if cache_key not in build_cache:
                     from .models import Firmware as FirmwareModel
 
@@ -411,6 +416,8 @@ def ingest_logs():
                             Version.version == version_number,
                             Version.package.has(name=package_name),
                         )
+                        .join(Build.architectures)
+                        .filter(Architecture.code == arch_code)
                     )
                     if target_firmware_build is not None:
                         build_query = build_query.filter(


### PR DESCRIPTION
This is a follow-on for https://github.com/SynoCommunity/spkrepo/pull/216 to address a minor bug.

## Summary

The `ingest_logs` build cache was keyed only by `(package, version)` and
returned the first build found with no architecture filter. SRM-targeted
builds (with lower IDs) were being assigned to DSM download events,
causing download counts to appear under the wrong architecture and firmware
in all views.

### Fix
- Include `arch_code` in the cache key: `(package, version, arch, target_fw)`
- Join `Build.architectures` and filter by `Architecture.code == arch_code`
  when looking up the build for each log entry

A DSM NAS with arch `88f628x` downloading transmission v20 now correctly
resolves to the DSM build that supports `88f628x` instead of the SRM build
(which only supports `northstarplus-ipq806x-dakota`).

### Backfill
An UPDATE query is provided in the PR to re-match existing download stats
rows to their correct build based on architecture and firmware range.
