### PR TITLE
Fix: noarch handling in ingest and correct target firmware attribution

### DIFF
--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -315,9 +315,10 @@ def ingest_logs():
         filename = path.rsplit("/", 1)[-1] if "/" in path else path
         fm = re.search(r"\.f(\d+)\[([^\]]+)\]", filename)
         if fm:
-            target_firmware_build = int(fm.group(1))
             archs = fm.group(2).split("-")
             target_noarch = "noarch" in archs
+            if not target_noarch:
+                target_firmware_build = int(fm.group(1))
 
         return (
             package_name,
@@ -417,7 +418,12 @@ def ingest_logs():
                             Version.package.has(name=package_name),
                         )
                         .join(Build.architectures)
-                        .filter(Architecture.code == arch_code)
+                        .filter(
+                            db.or_(
+                                Architecture.code == arch_code,
+                                Architecture.code == "noarch",
+                            )
+                        )
                     )
                     if target_firmware_build is not None:
                         build_query = build_query.filter(


### PR DESCRIPTION
This is a follow-on for https://github.com/SynoCommunity/spkrepo/pull/216 to address a minor bug.

## Summary

Two related fixes:

### 1. Architecture filter for noarch builds
The build lookup join on `build_architecture` was filtering by
`Architecture.code == arch_code` only, which failed to match noarch builds
when the client architecture was anything other than "noarch". The fix adds
an `OR` condition matching `Architecture.code == "noarch"`, matching the
existing catalog query behavior.

### 2. Noarch builds should not set target_firmware_build
Noarch packages have a firmware number in their filename (e.g. `f6931`) but
this is just the build system's minimum compatible firmware — the package
is not built exclusively for that firmware. Previously noarch downloads
would appear under SRM firmware versions in the "By Build" column, which
was misleading. Now noarch downloads set `target_firmware_build = NULL` and
`target_noarch = True`, so they correctly appear in the noarch architecture's
"By Build" column and not under any specific firmware.
