### PR TITLE
Feat: track manual downloads with download_source column

### DIFF
--- a/migrations/versions/1fa3599ed198_add_download_source_enum_make_arch_id_.py
+++ b/migrations/versions/1fa3599ed198_add_download_source_enum_make_arch_id_.py
@@ -1,0 +1,48 @@
+"""add download_source enum, make arch_id and fw_build nullable
+
+Revision ID: 1fa3599ed198
+Revises: 325d7d86f788
+Create Date: 2026-06-16 05:34:26.729294
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1fa3599ed198"
+down_revision: Union[str, Sequence[str], None] = "325d7d86f788"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "download_stat",
+        sa.Column(
+            "download_source",
+            sa.Enum("catalog", "manual", name="download_source"),
+            server_default="catalog",
+            nullable=False,
+        ),
+    )
+    op.alter_column(
+        "download_stat", "architecture_id", existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        "download_stat", "firmware_build", existing_type=sa.INTEGER(), nullable=True
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.alter_column(
+        "download_stat", "firmware_build", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.alter_column(
+        "download_stat", "architecture_id", existing_type=sa.INTEGER(), nullable=False
+    )
+    op.drop_column("download_stat", "download_source")

--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -351,9 +351,10 @@ def ingest_logs():
     counts = defaultdict(int)
     build_ids = {}  # agg_key -> build_id or None
     target_noarchs = {}  # agg_key -> bool
+    download_sources = {}  # agg_key -> str
     processed_keys = []
 
-    skipped_no_arch = 0
+    manual_downloads = 0
     skipped_no_build = 0
 
     for obj in objects:
@@ -386,10 +387,6 @@ def ingest_logs():
                     target_noarch,
                 ) = parsed
 
-                if arch_code is None or firmware_build is None:
-                    skipped_no_arch += 1
-                    continue
-
                 if url_path not in build_cache:
                     build = (
                         db.session.query(Build).filter(Build.path == url_path).first()
@@ -405,10 +402,21 @@ def ingest_logs():
                     continue
                 build_id, package_id = cached
 
-                if arch_code not in arch_cache:
-                    arch = Architecture.find(arch_code, syno=True)
-                    arch_cache[arch_code] = arch.id
-                architecture_id = arch_cache[arch_code]
+                if arch_code is not None:
+                    if arch_code not in arch_cache:
+                        arch = Architecture.find(arch_code, syno=True)
+                        arch_cache[arch_code] = arch.id
+                    architecture_id = arch_cache[arch_code]
+                else:
+                    architecture_id = None
+
+                if arch_code is None or firmware_build is None:
+                    arch_code = None
+                    firmware_build = None
+                    manual_downloads += 1
+                    download_source = "manual"
+                else:
+                    download_source = "catalog"
 
                 agg_key = (
                     package_id,
@@ -419,6 +427,7 @@ def ingest_logs():
                 )
                 counts[agg_key] += 1
                 target_noarchs[agg_key] = target_noarch
+                download_sources[agg_key] = download_source
 
                 if agg_key not in build_ids:
                     build_ids[agg_key] = build_id
@@ -438,6 +447,7 @@ def ingest_logs():
                 "firmware_build": firmware_build,
                 "target_firmware_build": target_firmware_build,
                 "target_noarch": target_noarchs.get(agg_key, False),
+                "download_source": download_sources.get(agg_key, "catalog"),
                 "date": record_date,
                 "count": count,
             }
@@ -481,9 +491,9 @@ def ingest_logs():
 
     logger.info(
         "Ingested %d download events from %d file(s). "
-        "Skipped — missing arch/firmware: %d, unknown build path: %d.",
+        "Skipped — unknown build path: %d. Manual downloads: %d.",
         sum(counts.values()),
         len(processed_keys),
-        skipped_no_arch,
         skipped_no_build,
+        manual_downloads,
     )

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -357,11 +357,16 @@ class DownloadStat(db.Model):
         index=True,
     )
     architecture_id = db.Column(
-        db.Integer, db.ForeignKey("architecture.id"), nullable=False, index=True
+        db.Integer, db.ForeignKey("architecture.id"), nullable=True, index=True
     )
-    firmware_build = db.Column(db.Integer, nullable=False, index=True)
+    firmware_build = db.Column(db.Integer, nullable=True, index=True)
     target_firmware_build = db.Column(db.Integer, nullable=True, index=True)
     target_noarch = db.Column(db.Boolean, nullable=False, default=False)
+    download_source = db.Column(
+        db.Enum("catalog", "manual", name="download_source"),
+        nullable=False,
+        server_default="catalog",
+    )
     date = db.Column(db.Date, nullable=False, index=True)
     count = db.Column(db.Integer, nullable=False, default=0)
 


### PR DESCRIPTION
## Summary

Adds a `download_source` enum column (`catalog` / `manual`) to `download_stat`
to distinguish between NAS Package Center downloads and manual/browser/curl
downloads that lack the NAS architecture and firmware headers.

### Changes

- **Schema**: `download_source` enum column added to `download_stat`.
  `architecture_id` and `firmware_build` made nullable since manual downloads
  don't have a known NAS identity.
- **Ingest**: Log entries without `arch`/`fw` headers are now ingested instead
  of skipped. They get `download_source = 'manual'`, `architecture_id = NULL`,
  and `firmware_build = NULL`. If either field is missing, both are set to
  NULL for consistency.
- **Views**: Manual downloads appear in "By Build" columns (via
  `target_firmware_build`/`target_noarch` parsed from the filename) but not in
  "By NAS" columns (since NAS identity is unknown).
- **Migration `1fa3599ed198`**: Adds the enum column, alters both existing
  columns to nullable. Existing rows get `download_source = 'catalog'` via
  server default — no data backfill needed.
