### PR TITLE
Fix: make enum migrations portable and fix CREATE TYPE before add_column

### DIFF
--- a/migrations/versions/1fa3599ed198_add_download_source_enum_make_arch_id_.py
+++ b/migrations/versions/1fa3599ed198_add_download_source_enum_make_arch_id_.py
@@ -20,11 +20,16 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    is_pg = op.get_bind().engine.dialect.name == "postgresql"
+    if is_pg:
+        op.execute(
+            "CREATE TYPE IF NOT EXISTS download_source AS ENUM ('catalog', 'manual')"
+        )
     op.add_column(
         "download_stat",
         sa.Column(
             "download_source",
-            sa.Enum("catalog", "manual", name="download_source"),
+            sa.Enum("catalog", "manual", name="download_source", create_type=not is_pg),
             server_default="catalog",
             nullable=False,
         ),
@@ -46,3 +51,5 @@ def downgrade() -> None:
         "download_stat", "architecture_id", existing_type=sa.INTEGER(), nullable=False
     )
     op.drop_column("download_stat", "download_source")
+    if op.get_bind().engine.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS download_source")

--- a/migrations/versions/1fa3599ed198_add_download_source_enum_make_arch_id_.py
+++ b/migrations/versions/1fa3599ed198_add_download_source_enum_make_arch_id_.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
     is_pg = op.get_bind().engine.dialect.name == "postgresql"
     if is_pg:
         op.execute(
-            "CREATE TYPE IF NOT EXISTS download_source AS ENUM ('catalog', 'manual')"
+            "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'download_source') THEN CREATE TYPE download_source AS ENUM ('catalog', 'manual'); END IF; END $$"
         )
     op.add_column(
         "download_stat",

--- a/migrations/versions/3fdb8480a9f5_add_storage_and_signed_columns_to_build.py
+++ b/migrations/versions/3fdb8480a9f5_add_storage_and_signed_columns_to_build.py
@@ -23,7 +23,7 @@ def upgrade() -> None:
     is_pg = op.get_bind().engine.dialect.name == "postgresql"
     if is_pg:
         op.execute(
-            "CREATE TYPE IF NOT EXISTS storage_location AS ENUM ('local', 'remote')"
+            "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'storage_location') THEN CREATE TYPE storage_location AS ENUM ('local', 'remote'); END IF; END $$"
         )
     op.add_column(
         "build",

--- a/migrations/versions/3fdb8480a9f5_add_storage_and_signed_columns_to_build.py
+++ b/migrations/versions/3fdb8480a9f5_add_storage_and_signed_columns_to_build.py
@@ -20,11 +20,16 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
+    is_pg = op.get_bind().engine.dialect.name == "postgresql"
+    if is_pg:
+        op.execute(
+            "CREATE TYPE IF NOT EXISTS storage_location AS ENUM ('local', 'remote')"
+        )
     op.add_column(
         "build",
         sa.Column(
             "storage",
-            sa.Enum("local", "remote", name="storage_location"),
+            sa.Enum("local", "remote", name="storage_location", create_type=not is_pg),
             nullable=False,
             server_default="local",
         ),
@@ -39,3 +44,5 @@ def downgrade() -> None:
     """Downgrade schema."""
     op.drop_column("build", "signed")
     op.drop_column("build", "storage")
+    if op.get_bind().engine.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS storage_location")

--- a/migrations/versions/76d559b4e873_add_fs_uniquifier.py
+++ b/migrations/versions/76d559b4e873_add_fs_uniquifier.py
@@ -14,13 +14,14 @@ down_revision = "d429595e8362"
 
 
 def upgrade():
+    is_pg = op.get_bind().engine.dialect.name == "postgresql"
     op.add_column(
         "user",
         sa.Column(
             "fs_uniquifier",
             sa.String(length=255),
             nullable=False,
-            server_default=sa.text("md5(random()::text)"),
+            server_default=sa.text("md5(random()::text)") if is_pg else None,
         ),
     )
     op.create_unique_constraint("user_fs_uniquifier_key", "user", ["fs_uniquifier"])


### PR DESCRIPTION
This is a follow-on for https://github.com/SynoCommunity/spkrepo/pull/228 to address a bug.

### Problem
Migration `1fa3599ed198` (download_source enum) failed on production with
`type "download_source" does not exist`. Alembic's `op.add_column()` with
`sa.Enum()` does not auto-create the PostgreSQL enum type — the type must
exist before the column references it. The same latent bug existed in
migration `3fdb8480a9f5` (storage_location enum).

### Changes
- **`3fdb8480a9f5`** (`storage_location`): Added `is_pg` dialect check.
  On PG, creates the enum type via `DO $$ ... pg_type ... $$` before
  `add_column` with `create_type=False`. On SQLite, uses `sa.Enum()`
  with `create_type=True` (auto VARCHAR+CHECK).
- **`1fa3599ed198`** (`download_source`): Same pattern — dialect check,
  manual type creation, `create_type=False` on PG.
- **`76d559b4e873`** (`fs_uniquifier`): Wrapped PG-specific
  `md5(random()::text)` server default in `if is_pg` check.
- **All three** use `op.get_bind().engine.dialect.name` for dialect
  detection, matching the existing portable migration pattern.

### Verification
Ran full migration chain rollback-to-base and roll-forward on dev
database — all migrations apply cleanly. All 286 tests pass on SQLite.
