### PR TITLE
feat: multi-arch Docker image support (amd64, arm64)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,17 +26,22 @@ jobs:
         with:
           path: /tmp/.uv-cache
           key: uv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+
       - name: Install dependencies
         if: steps.cached-uv-dependencies.outputs.cache-hit != 'true'
         run: uv sync --locked --no-install-project --all-extras --dev
+
       - name: Install project
         run: uv sync --locked --all-extras --dev
+
       - name: Build
         run: uv build
+
       - name: Publish to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
         run: uv publish
+
       - name: Minimize uv cache
         run: uv cache prune --ci
 
@@ -47,21 +52,33 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
+
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
-FROM python:3.12
+FROM python:3.12-slim
 
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install -y \
-    gnupg \
- && rm -rf /var/lib/apt/lists/*
-
-
-RUN pip install --no-cache-dir gunicorn psycopg2 redis
-
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gnupg curl gcc libpq-dev \
+ && pip install --no-cache-dir gunicorn psycopg2 redis -r requirements.txt \
+ && apt-get purge -y --auto-remove gcc \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY spkrepo ./spkrepo
 COPY migrations ./migrations
@@ -19,6 +16,7 @@ COPY celery_app.py ./
 
 HEALTHCHECK --interval=1m --timeout=5s \
   CMD curl -f http://localhost:8000/ || exit 1
+
 VOLUME [ "/data" ]
 EXPOSE 8000
 CMD [ "gunicorn", "-b", "0.0.0.0:8000", "-w", "5", "wsgi:app" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /usr/src/app
 COPY requirements.txt ./
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg curl gcc libpq-dev \
- && pip install --no-cache-dir gunicorn psycopg2 redis -r requirements.txt \
+ && pip install --no-cache-dir uv \
+ && uv pip install --system --no-cache gunicorn psycopg2 redis -r requirements.txt \
  && apt-get purge -y --auto-remove gcc \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
Updates the publish pipeline and Dockerfile to build and push multi-architecture Docker images for both `linux/amd64` and `linux/arm64`.

## Changes

### `.github/workflows/publish.yml`
- Add `docker/setup-qemu-action@v3` for arm64 emulation on GitHub-hosted runners
- Add `docker/setup-buildx-action@v3` to enable multi-platform builds
- Add `platforms: linux/amd64,linux/arm64` to the build-push step
- Add GitHub Actions layer caching (`cache-from/cache-to: type=gha,mode=max`) to speed up repeat builds
- Bump `metadata-action` v4 → v5, `login-action` v2 → v3, `build-push-action` v4 → v5

### `Dockerfile`
- Switch base image from `python:3.12` to `python:3.12-slim` for better multi-arch support and smaller image size
- Add `curl` (fixes existing broken `HEALTHCHECK`), `gcc`, and `libpq-dev` to support building `psycopg2` from source on slim
- Use `--no-install-recommends` to avoid pulling in unnecessary packages
- Consolidate `apt-get install`, `pip install`, `apt-get purge`, and `apt-get clean` into a single `RUN` layer so build deps don't bloat the final image
- Move `COPY requirements.txt` before the install step to improve layer cache reuse

## Notes
- arm64 builds run via QEMU emulation on standard GitHub runners; build times will be longer than before
- The `pypi` job is unchanged as the wheels are pure Python