### PR TITLE
fix: use release published event instead of created to avoid tag race condition

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   pypi:


### PR DESCRIPTION
Use `release: published` instead of `release: created` to avoid a race condition where the git tag may not yet exist when the workflow starts. This causes `docker/metadata-action` to produce no tags, and the Docker build fails with "tag is needed when pushing to registry." Deleting and re-creating the release works around it because the tag exists by then — `published` prevents the race entirely.