### PR TITLE
feat: use PackageDownloadCounts MV for frontend and admin download stats

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -926,6 +926,13 @@ class Package(db.Model):
         back_populates="package",
         cascade="all, delete-orphan",
     )
+    download_counts = db.relationship(
+        "PackageDownloadCounts",
+        primaryjoin="Package.id == PackageDownloadCounts.package_id",
+        foreign_keys="PackageDownloadCounts.package_id",
+        uselist=False,
+        viewonly=True,
+    )
 
     # Constraints
     __table_args__ = (db.UniqueConstraint(name),)

--- a/spkrepo/templates/frontend/package.html
+++ b/spkrepo/templates/frontend/package.html
@@ -10,6 +10,48 @@
       <h1>{{ package.versions[-1].displaynames['enu'].displayname }}
         <small class="text-muted">v{{ package.versions[-1].version_string }}</small>
       </h1>
+
+      {# Active installs badge — only shown when package has meaningful recent downloads #}
+      {% if package.download_counts %}
+        {% set n = package.download_counts.recent_download_count %}
+        {% if n >= 100000 %}
+          <p>
+            <span class="badge badge-dark badge-pill">100k+ installs</span>
+            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+          </p>
+        {% elif n >= 50000 %}
+          <p>
+            <span class="badge badge-primary badge-pill">50k+ installs</span>
+            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+          </p>
+        {% elif n >= 25000 %}
+          <p>
+            <span class="badge badge-primary badge-pill">25k+ installs</span>
+            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+          </p>
+        {% elif n >= 10000 %}
+          <p>
+            <span class="badge badge-info badge-pill">10k+ installs</span>
+            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+          </p>
+        {% elif n >= 5000 %}
+          <p>
+            <span class="badge badge-success badge-pill">5k+ installs</span>
+            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+          </p>
+        {% elif n >= 2500 %}
+          <p>
+            <span class="badge badge-success badge-pill">2.5k+ installs</span>
+            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+          </p>
+        {% elif n >= 1000 %}
+          <p>
+            <span class="badge badge-secondary badge-pill">1k+ installs</span>
+            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+          </p>
+        {% endif %}
+      {% endif %}
+
       <p>{{ package.versions[-1].builds[0].descriptions['enu'].description }}</p>
       <div class="package-screenshots">
         {% for screenshot in package.screenshots %}

--- a/spkrepo/templates/frontend/packages.html
+++ b/spkrepo/templates/frontend/packages.html
@@ -1,6 +1,28 @@
 {% extends 'layout.html' %}
 {% block title %}Packages - {{ super() }}{% endblock %}
 {% block content %}
+
+{% macro installs_badge(counts) %}
+  {% if counts %}
+    {% set n = counts.recent_download_count %}
+    {% if n >= 100000 %}
+      <span class="badge badge-dark" title="Based on downloads in last 90 days">100k+ installs</span>
+    {% elif n >= 50000 %}
+      <span class="badge badge-primary" title="Based on downloads in last 90 days">50k+ installs</span>
+    {% elif n >= 25000 %}
+      <span class="badge badge-primary" title="Based on downloads in last 90 days">25k+ installs</span>
+    {% elif n >= 10000 %}
+      <span class="badge badge-info" title="Based on downloads in last 90 days">10k+ installs</span>
+    {% elif n >= 5000 %}
+      <span class="badge badge-success" title="Based on downloads in last 90 days">5k+ installs</span>
+    {% elif n >= 2500 %}
+      <span class="badge badge-success" title="Based on downloads in last 90 days">2.5k+ installs</span>
+    {% elif n >= 1000 %}
+      <span class="badge badge-secondary" title="Based on downloads in last 90 days">1k+ installs</span>
+    {% endif %}
+  {% endif %}
+{% endmacro %}
+
 <div id="packages">
   {% for version_row in versions | batch(3) %}
   <div class="row package-row">
@@ -19,6 +41,7 @@
           <div class="ellipsis package-description">
             <p>{{ version.builds[0].descriptions['enu'].description }}</p>
           </div>
+          {{ installs_badge(version.package.download_counts) }}
         </div>
       </div>
     </div>

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -875,8 +875,8 @@ class PackageView(ModelView):
         ("name", "name"),
         ("author", "author.username"),
         ("insert_date", "insert_date"),
-        ("download_count", "download_count"),
-        ("recent_download_count", "recent_download_count"),
+        ("download_count", "download_counts.download_count"),
+        ("recent_download_count", "download_counts.recent_download_count"),
         ("last_download_date", "last_download_date"),
     )
     column_formatters = {
@@ -884,10 +884,14 @@ class PackageView(ModelView):
             m.insert_date.strftime("%Y-%m-%d") if m.insert_date else None
         ),
         "download_count": lambda v, c, m, p: (
-            f"{m.download_count:,}" if m.download_count else "0"
+            f"{m.download_counts.download_count:,}"
+            if m.download_counts and m.download_counts.download_count
+            else "0"
         ),
         "recent_download_count": lambda v, c, m, p: (
-            f"{m.recent_download_count:,}" if m.recent_download_count else "0"
+            f"{m.download_counts.recent_download_count:,}"
+            if m.download_counts and m.download_counts.recent_download_count
+            else "0"
         ),
         "last_download_date": lambda v, c, m, p: (
             m.last_download_date.strftime("%Y-%m-%d") if m.last_download_date else None

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -74,7 +74,7 @@ def packages():
         versions = (
             Version.query.join(Version.package)
             .options(
-                db.joinedload(Version.package),
+                db.joinedload(Version.package).joinedload(Package.download_counts),
                 db.joinedload(Version.icons),
                 db.joinedload(Version.displaynames).joinedload(DisplayName.language),
                 db.joinedload(Version.builds)
@@ -100,6 +100,7 @@ def package(name):
     pkg = (
         Package.query.filter_by(name=name)
         .options(
+            db.joinedload(Package.download_counts),
             db.joinedload(Package.versions).joinedload(Version.icons),
             db.joinedload(Package.versions).joinedload(Version.displaynames),
             db.joinedload(Package.versions)


### PR DESCRIPTION
## Summary

- Add `Package.download_counts` relationship to the `PackageDownloadCounts`
  materialized view (replaces expensive deferred column_property subqueries)
- Admin PackageView: sort and display counts via the MV relationship
- Frontend: eager load download counts on packages list and detail pages
- Package detail page: add install badge (100k/50k/25k/10k/5k/2.5k/1k+)
  based on recent 90-day downloads, with tiered badge colours
- Packages list page: add install badge macro to each package card