### PR TITLE
fix: exclude materialized view from Alembic autogenerate

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -23,6 +23,18 @@ config.set_main_option(
 # target_metadata = mymodel.Base.metadata
 target_metadata = current_app.extensions["migrate"].db.metadata
 
+# Tables that are managed outside of Alembic (e.g. materialized views)
+# and should be excluded from autogenerate comparisons.
+EXCLUDE_TABLES = {"package_download_counts"}
+
+
+def include_object(object, name, type_, reflected, compare_to):
+    """Tell Alembic to ignore tables managed outside of migrations."""
+    if type_ == "table" and name in EXCLUDE_TABLES:
+        return False
+    return True
+
+
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
@@ -47,6 +59,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        include_object=include_object,
     )
 
     with context.begin_transaction():
@@ -71,6 +84,7 @@ def run_migrations_online() -> None:
             connection=connection,
             target_metadata=target_metadata,
             render_as_batch=connection.dialect.name == "sqlite",
+            include_object=include_object,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
## Summary

- Exclude `package_download_counts` materialized view from Alembic
  autogenerate via `include_object` callback
- Prevents `flask db migrate` from detecting the MV as an unmanaged table
