### PR TITLE
fix: move install badge below package name on packages list

### DIFF
--- a/spkrepo/templates/frontend/packages.html
+++ b/spkrepo/templates/frontend/packages.html
@@ -38,10 +38,10 @@
           <h5>{{ version.displaynames['enu'].displayname }}
             <small class="text-muted">v{{ version.version_string }}</small>
           </h5>
+          {{ installs_badge(version.package.download_counts) }}
           <div class="ellipsis package-description">
             <p>{{ version.builds[0].descriptions['enu'].description }}</p>
           </div>
-          {{ installs_badge(version.package.download_counts) }}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Move install badge from below the description to below the package name
  on the packages list page, matching the detail page layout