### PR TITLE
feat: separate active and archived packages on packages list

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -934,6 +934,17 @@ class Package(db.Model):
         viewonly=True,
     )
 
+    has_active_builds = db.column_property(
+        db.exists(
+            db.select(db.literal(1))
+            .select_from(Build)
+            .join(Version, Build.version_id == Version.id)
+            .where(Version.package_id == id)
+            .where(Build.active)
+        ),
+        deferred=True,
+    )
+
     # Constraints
     __table_args__ = (db.UniqueConstraint(name),)
 

--- a/spkrepo/templates/frontend/package.html
+++ b/spkrepo/templates/frontend/package.html
@@ -4,12 +4,24 @@
 <div class="row">
   <div class="d-flex">
     <div class="flex-shrink-0 mr-3">
-      <img src="{{ url_for('nas.data', path=package.versions[-1].icons['72'].path) }}" alt="Icon">
+      {% set _icon = package.versions[-1].icons.get("256") or package.versions[-1].icons["72"] %}
+      <img src="{{ url_for('nas.data', path=_icon.path) }}" alt="Icon"
+           style="{% if "256" in package.versions[-1].icons %}width:128px;{% endif %}height:auto;{% if not package.has_active_builds %} filter: grayscale(60%);{% endif %}">
     </div>
     <div class="flex-grow-1">
       <h1>{{ package.versions[-1].displaynames['enu'].displayname }}
         <small class="text-muted">v{{ package.versions[-1].version_string }}</small>
+        {% if not package.has_active_builds %}
+          <span class="badge badge-secondary ml-1">Archived</span>
+        {% endif %}
       </h1>
+
+      {% if not package.has_active_builds %}
+      <div class="alert alert-secondary py-2" role="alert">
+        <i class="bi bi-archive mr-2"></i>
+        This package is no longer in the active catalog and is not actively maintained.
+      </div>
+      {% endif %}
 
       {# Active installs badge — only shown when package has meaningful recent downloads #}
       {% if package.download_counts %}

--- a/spkrepo/templates/frontend/packages.html
+++ b/spkrepo/templates/frontend/packages.html
@@ -23,30 +23,79 @@
   {% endif %}
 {% endmacro %}
 
-<div id="packages">
-  {% for version_row in versions | batch(3) %}
-  <div class="row package-row">
-    {% for version in version_row %}
-    <div class="col-md-4">
-      <div class="d-flex">
-        <div class="flex-shrink-0 mr-3" style="width: 72px;">
-          <a href="{{ url_for('frontend.package', name=version.package.name) }}">
-            <img src="{{ url_for('nas.data', path=version.icons['72'].path) }}" alt="Icon">
-          </a>
-        </div>
-        <div class="flex-grow-1">
-          <h5>{{ version.displaynames['enu'].displayname }}
-            <small class="text-muted">v{{ version.version_string }}</small>
-          </h5>
-          {{ installs_badge(version.package.download_counts) }}
-          <div class="ellipsis package-description">
-            <p>{{ version.builds[0].descriptions['enu'].description }}</p>
-          </div>
-        </div>
+{% macro package_card(version, archived=false) %}
+<div class="col-md-4">
+  <div class="d-flex{% if archived %}" style="opacity: 0.6;{% endif %}">
+    <div class="flex-shrink-0 mr-3" style="width: 72px;">
+      <a href="{{ url_for('frontend.package', name=version.package.name) }}">
+        <img src="{{ url_for('nas.data', path=version.icons['72'].path) }}" alt="Icon"
+             {% if archived %}style="filter: grayscale(60%);"{% endif %}>
+      </a>
+    </div>
+    <div class="flex-grow-1">
+      <h5>{{ version.displaynames['enu'].displayname }}
+        <small class="text-muted">v{{ version.version_string }}</small>
+        {% if archived %}
+          <span class="badge badge-secondary ml-1">Archived</span>
+        {% endif %}
+      </h5>
+      {% if not archived %}
+        {{ installs_badge(version.package.download_counts) }}
+      {% endif %}
+      <div class="ellipsis package-description">
+        <p>{{ version.builds[0].descriptions['enu'].description }}</p>
       </div>
     </div>
+  </div>
+</div>
+{% endmacro %}
+
+{# Split versions into active and archived.
+   A package is considered archived only if no build across any of its
+   versions is active. All versions' builds are pre-loaded in frontend.py
+   via the Package.versions -> Version.builds joinedload chain. #}
+{% set active_versions = [] %}
+{% set archived_versions = [] %}
+{% for version in versions %}
+  {% if version.package.has_active_builds %}
+    {% set _ = active_versions.append(version) %}
+  {% else %}
+    {% set _ = archived_versions.append(version) %}
+  {% endif %}
+{% endfor %}
+
+<div id="packages">
+
+  {# ── Active packages ── #}
+  {% for version_row in active_versions | batch(3) %}
+  <div class="row package-row">
+    {% for version in version_row %}
+      {{ package_card(version) }}
     {% endfor %}
   </div>
   {% endfor %}
+
+  {# ── Archived packages ── #}
+  {% if archived_versions %}
+  <div class="row mt-5 mb-2">
+    <div class="col-12">
+      <h4 class="text-muted">
+        <i class="bi bi-archive mr-2"></i>Archived Packages
+      </h4>
+      <p class="text-muted small">
+        These packages are no longer in the active catalog and are not actively maintained.
+      </p>
+      <hr>
+    </div>
+  </div>
+  {% for version_row in archived_versions | batch(3) %}
+  <div class="row package-row archived-package-row">
+    {% for version in version_row %}
+      {{ package_card(version, archived=true) }}
+    {% endfor %}
+  </div>
+  {% endfor %}
+  {% endif %}
+
 </div>
 {% endblock %}

--- a/spkrepo/templates/layout.html
+++ b/spkrepo/templates/layout.html
@@ -12,6 +12,7 @@
 
     <!-- Bootstrap 4 CSS -->
     <link href="{{ url_for('static', filename='css/bootstrap.min.css') }}" rel="stylesheet">
+    <link href="{{ url_for('static', filename='css/bootstrap-icons.min.css') }}" rel="stylesheet">
 
     <!-- spkrepo -->
     <link href="{{ url_for('static', filename='css/spkrepo.css') }}" rel="stylesheet">

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -75,6 +75,7 @@ def packages():
             Version.query.join(Version.package)
             .options(
                 db.joinedload(Version.package).joinedload(Package.download_counts),
+                db.joinedload(Version.package).undefer(Package.has_active_builds),
                 db.joinedload(Version.icons),
                 db.joinedload(Version.displaynames).joinedload(DisplayName.language),
                 db.joinedload(Version.builds)

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -240,6 +240,11 @@ def build_package_entry(b, language, arch, build, counts_by_package):
     _set_if_truthy(entry, "md5", b.md5)
     _set_if_truthy(entry, "size", b.size)
 
+    _retina_icon = b.version.icons.get("256")
+    if _retina_icon:
+        _retina_url = url_for(".data", path=_retina_icon.path, _external=True)
+        entry["thumbnail_retina"] = [_retina_url, _retina_url]
+
     if b.version.startable is not None:
         entry["startable"] = "yes" if b.version.startable else "no"
 


### PR DESCRIPTION
## Summary

- Split packages list into active and archived sections based on `Package.has_active_builds` property
- Add archived banner, badge, and grayscale icon on detail page for inactive packages
- Move Bootstrap Icons CSS to layout template for site-wide availability
- Use 256px retina icon on package detail page (displayed at 128px), fall back to 72px
- Add `thumbnail_retina` key to NAS catalog response (two copies of 256px URL when available)