### PR TITLE
fix: apply archived filter to count query for correct pagination

### DIFF
--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -886,7 +886,13 @@ class PackageView(ModelView):
         return q
 
     def get_count_query(self):
-        return super().get_count_query()
+        q = super().get_count_query()
+        archived = request.args.get("archived")
+        if archived == "yes":
+            q = q.filter(~Package.has_active_builds)
+        elif archived == "no":
+            q = q.filter(Package.has_active_builds)
+        return q
 
     column_list = (
         "name",


### PR DESCRIPTION
## Summary

Fix pagination count when filtering by archived status in the Package admin
view (#260). The `get_count_query` was not applying the same `?archived=yes/no`
filter as `get_query`, causing the page counter to show the total number of
unfiltered pages.