### PR TITLE
fix: catch all requests exceptions in timestamp signing

### DIFF
--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -350,7 +350,7 @@ class SPK(object):
             response = requests.post(
                 timestamp_url, files={"file": signature.data}, timeout=2
             )
-        except requests.Timeout:
+        except requests.RequestException:
             raise SPKSignError("Timestamp server did not respond in time")
 
         if response.status_code != 200:

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -898,7 +898,6 @@ class PackageView(ModelView):
         "name",
         "author",
         "maintainers",
-        "has_active_builds",
         "download_count",
         "recent_download_count",
         "last_download_date",
@@ -918,11 +917,6 @@ class PackageView(ModelView):
     column_formatters = {
         "insert_date": lambda v, c, m, p: (
             m.insert_date.strftime("%Y-%m-%d") if m.insert_date else None
-        ),
-        "has_active_builds": lambda v, c, m, p: (
-            Markup('<i class="fa fa-check-circle text-success"></i>')
-            if not m.has_active_builds
-            else Markup('<i class="fa fa-times-circle text-danger"></i>')
         ),
         "download_count": lambda v, c, m, p: (
             f"{m.download_counts.download_count:,}"


### PR DESCRIPTION
## Summary

- Fix: catch all `requests.RequestException` instead of just `Timeout` in
  `_generate_signature`, preventing gunicorn worker crashes when the
  timestamp server is unreachable (Network is unreachable, DNS failure, etc.)
- Remove `has_active_builds` column from Package list view (not sortable;
  filter dropdown remains; column still visible on detail page)