### PR TITLE
fix: use _bool_formatter for active column in UserView

### DIFF
--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -499,9 +499,10 @@ class UserView(ModelView):
 
     column_list = ("username", "email", "roles", "active", "confirmed_at")
     column_formatters = {
+        "active": _bool_formatter,
         "confirmed_at": lambda v, c, m, p: (
             m.confirmed_at.strftime("%Y-%m-%d %H:%M:%S") if m.confirmed_at else None
-        )
+        ),
     }
 
     form_columns = ("username", "roles", "active")


### PR DESCRIPTION
## Summary

- Use `_bool_formatter` for the `active` column in the User admin view,
  consistent with all other boolean columns in the interface