### PR TITLE
fix: prevent RTD addon JS from clearing sidebar

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,11 @@
+{% extends "pydata_sphinx_theme/layout.html" %}
+
+{% block docs_sidebar %}
+<div id="pst-primary-sidebar" class="bd-sidebar-primary bd-sidebar">
+  <div class="sidebar-primary-items__start sidebar-primary__section">
+    <div class="sidebar-primary-item">
+      {% include "sidebar-nav-bs.html" %}
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,25 +56,29 @@ html_theme_options = {
         },
     ],
     "secondary_sidebar_items": ["page-toc"],
-    # Prevent RTD addon system from taking over the sidebar
     "logo": {
         "text": _project_title,
     },
+    # Explicitly declare sidebar contents so pydata owns the slot entirely,
+    # preventing RTD's addon JS from clearing it.
+    "primary_sidebar_end": [],
+    "article_footer_items": [],
+    "content_footer_items": [],
+    "footer_start": ["copyright"],
+    "footer_end": [],
 }
 html_context = {
     "github_user": "SynoCommunity",
     "github_repo": "spkrepo",
     "github_version": "main",
     "doc_path": "docs",
-    # Tell pydata this is an RTD build so it uses compatible sidebar mode
-    "READTHEDOCS": True,
-    "readthedocs_url": "https://spkrepo.readthedocs.io",
 }
 
 html_static_path = ["_static"]
 
-# Left sidebar: site-wide navigation tree.
-# The in-page TOC is in the right sidebar via secondary_sidebar_items above.
+# Use pydata's built-in sidebar component. If RTD addon JS continues to
+# interfere, the fallback is to swap "sidebar-nav-bs" for "globaltoc.html"
+# which RTD does not target.
 html_sidebars = {
     "**": ["sidebar-nav-bs"],
 }


### PR DESCRIPTION
## Summary

- Override pydata-sphinx-theme `docs_sidebar` block with a custom template
  to prevent RTD's addon JS from clearing the sidebar
- Configure empty sidebar/footer sections to block JS interference
- Remove now-unnecessary RTD html_context flags
- Remove stale comments from conf.py