### PR TITLE
fix: collapse empty navbar center and align end items properly

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -70,3 +70,17 @@
     min-width: 160px;
     max-width: 260px;
 }
+
+/* ---------------------------------------------------------------
+   Navbar — collapse empty center zone and pull end items left
+--------------------------------------------------------------- */
+
+/* Hide the empty center slot so it doesn't push icons to the far right */
+.navbar-header-items__center {
+    display: none;
+}
+
+/* Pull end items flush after the logo */
+.bd-navbar .navbar-header-items {
+    justify-content: flex-end;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,11 +46,10 @@ html_theme_options = {
     "navigation_with_keys": True,
     "use_edit_page_button": True,
     # No page links in navbar — navigation is entirely in the left sidebar.
-    # Setting navbar_align to "left" collapses the empty center reservation
-    # so the right-side icons sit close to the logo instead of floating far right.
     "navbar_center": [],
     "navbar_align": "left",
-    "navbar_end": ["search-field", "theme-switcher", "navbar-icon-links"],
+    # Omit search-field since RTD injects its own search addon.
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
     "icon_links": [
         {
             "name": "GitHub",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,21 +8,21 @@ Spkrepo is a feature rich Synology Package Repository application. It is compati
 and comes with an API, advanced permission management and an admin interface.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Getting Started
 
    quickstart
    deployment
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: API
 
    api
    api_examples
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :caption: Reference
 
    models


### PR DESCRIPTION
## Summary

- Hide empty navbar-center slot and pull navbar end items flush after logo
- Set navbar_align to "left" and omit search-field from navbar_end
  (RTD injects its own search addon)
- Reduce toctree maxdepth from 2 to 1 in index.rst for all sections