### PR TITLE
docs: fix command/endpoint references, remove production hostname

### DIFF
--- a/docs/api_examples.rst
+++ b/docs/api_examples.rst
@@ -28,7 +28,7 @@ and firmware version. Parameters are sent as POST form data:
 
 .. code-block:: console
 
-    http POST http://packages.synocommunity.com/ \
+    http POST http://packages.example.com/ \
         arch=apollolake \
         build=25556 \
         major=7 \
@@ -39,15 +39,3 @@ and firmware version. Parameters are sent as POST form data:
 
 The response is a JSON array of package entries with download URLs,
 descriptions, screenshots, and download counts.
-
-List architectures
-------------------
-.. code-block:: console
-
-    http http://localhost:5000/api/architectures
-
-List firmware
--------------
-.. code-block:: console
-
-    http http://localhost:5000/api/firmware

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -84,10 +84,10 @@ Start the worker and beat scheduler:
 .. code-block:: console
 
     # Worker (processes background tasks)
-    uv run celery -A spkrepo.celery worker -Q ops --loglevel=info
+    uv run celery -A celery_app:celery_app worker -Q ops --loglevel=info
 
     # Beat (dispatches scheduled tasks)
-    uv run celery -A spkrepo.celery beat --loglevel=info
+    uv run celery -A celery_app:celery_app beat --loglevel=info
 
 Database migrations
 -------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,7 +4,7 @@ Quickstart
 Prerequisites
 -------------
 - Docker and Docker Compose
-- Python 3.12 or later
+- Python 3.14 or later
 - `uv <https://docs.astral.sh/uv/>`_ (package manager)
 
 Setup
@@ -36,7 +36,7 @@ Register an admin user
 ----------------------
 .. code-block:: console
 
-    uv run flask spkrepo register_admin
+    uv run flask spkrepo create_admin
 
 Environment Variables
 ---------------------


### PR DESCRIPTION
## Summary

Fix several inaccuracies in the documentation that were out of sync with the codebase:

- `register_admin` → `create_admin` (actual CLI command at `spkrepo/cli.py:208`)
- `celery -A spkrepo.celery` → `celery -A celery_app:celery_app` (celery app is in `celery_app.py`, not a `spkrepo.celery` submodule)
- Removed `/api/architectures` and `/api/firmware` examples — those endpoints don't exist; the only API endpoint is `POST /api/packages`
- Updated Python version from 3.12 to 3.14 (project requires `>=3.14`)
- Replaced production hostname `packages.synocommunity.com` with placeholder `packages.example.com`

## Files changed

- **`docs/quickstart.rst`** — `register_admin` → `create_admin`, Python 3.12 → 3.14
- **`docs/api_examples.rst`** — removed dead `/api/architectures` and `/api/firmware` sections, production hostname → placeholder
- **`docs/deployment.rst`** — `spkrepo.celery` → `celery_app:celery_app` for worker and beat commands