### PR TITLE
fix: redirect browser requests from catalog to frontend packages page

### DIFF
--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -6,6 +6,7 @@ from flask import (
     abort,
     current_app,
     json,
+    redirect,
     request,
     send_from_directory,
     url_for,
@@ -268,6 +269,8 @@ def catalog():
         or "arch" not in request.values
         or "language" not in request.values
     ):
+        if request.accept_mimetypes.accept_html:
+            return redirect(url_for("frontend.packages"))
         abort(400)
 
     language = request.values["language"]


### PR DESCRIPTION
## Summary

When visiting the NAS catalog endpoint in a browser (e.g. `https://packages.synocommunity.com/`) without the required `build`, `arch`, and `language` parameters, the server returns a bare **400 Bad Request**. This is unhelpful for anyone accessing the URL manually.

## Change

In `spkrepo/views/nas.py`, the `catalog()` function now checks if the client accepts HTML (`request.accept_mimetypes.accept_html`). If so, it redirects to the frontend packages page instead of aborting with 400. NAS devices and programmatic clients without `Accept: text/html` still receive the 400 as before.

## Behavior

| Client | Before | After |
|---|---|---|
| Browser visiting `packages.synocommunity.com/` | 400 Bad Request | 302 → `synocommunity.com/packages` |
| NAS sending `build`/`arch`/`language` params | Normal catalog response | Unchanged |
| `curl https://packages.synocommunity.com/` | 400 Bad Request | 400 Bad Request (no change) |