### PR TITLE
refactor: refresh materialized view inline after ingest, remove Celery beat task

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -9,7 +9,6 @@ The production stack consists of:
 - **Redis** — Celery broker and Flask cache backend
 - **Gunicorn** — WSGI server, reverse-proxied behind **nginx**
 - **Celery worker** — processes background tasks on the ``ops`` queue
-- **Celery beat** — scheduled task dispatcher
 - **nginx** — reverse proxy and static file server
 - **CDN** — edge caching for the NAS catalog endpoint
 - **Object Storage** — S3-compatible storage (e.g. Fastly Object Storage) for SPK packages
@@ -79,15 +78,11 @@ A minimal nginx reverse proxy configuration:
 
 Celery workers
 --------------
-Start the worker and beat scheduler:
+Start the worker:
 
 .. code-block:: console
 
-    # Worker (processes background tasks)
     uv run celery -A celery_app:celery_app worker -Q ops --loglevel=info
-
-    # Beat (dispatches scheduled tasks)
-    uv run celery -A celery_app:celery_app beat --loglevel=info
 
 Database migrations
 -------------------

--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -505,3 +505,18 @@ def ingest_logs():
         skipped_no_build,
         manual_downloads,
     )
+
+    # Refresh the materialized view so download counts and badges reflect
+    # the newly ingested data immediately rather than waiting for a
+    # scheduled task.
+    if db.engine.dialect.name == "postgresql":
+        try:
+            db.session.execute(
+                db.text(
+                    "REFRESH MATERIALIZED VIEW CONCURRENTLY package_download_counts"
+                )
+            )
+            db.session.commit()
+            logger.info("Refreshed package_download_counts materialized view.")
+        except Exception as e:
+            logger.error("Failed to refresh package_download_counts: %s", e)

--- a/spkrepo/config.py
+++ b/spkrepo/config.py
@@ -77,12 +77,6 @@ CELERY = {
         "ops": {},  # admin-triggered background operations (upload, rehome, resync)
     },
     "task_default_queue": "celery",
-    "beat_schedule": {
-        "refresh-download-counts": {
-            "task": "spkrepo.views.tasks.refresh_download_counts",
-            "schedule": 3600,
-        },
-    },
 }
 
 # Debug Toolbar

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -414,8 +414,8 @@ class DownloadStat(db.Model):
 class PackageDownloadCounts(db.Model):
     """Read-only model backed by the package_download_counts materialized view.
 
-    Refreshed periodically by the refresh_download_counts Celery task.
-    Never written to directly — use REFRESH MATERIALIZED VIEW instead.
+    Refreshed after each ingest_logs run via REFRESH MATERIALIZED VIEW CONCURRENTLY.
+    Never written to directly.
     """
 
     __tablename__ = "package_download_counts"

--- a/spkrepo/templates/admin/package_detail.html
+++ b/spkrepo/templates/admin/package_detail.html
@@ -56,7 +56,7 @@
                   {% endfor %}
                 </table>
               {% else %}
-                <span class="text-muted">No downloads in the last 90 days</span>
+                <span class="text-muted">No NAS downloads in the last 90 days</span>
               {% endif %}
             {% elif c == 'firmware_breakdown' %}
               {% if firmware_breakdown %}
@@ -78,7 +78,7 @@
                   {% endfor %}
                 </table>
               {% else %}
-                <span class="text-muted">No downloads in the last 90 days</span>
+                <span class="text-muted">No NAS downloads in the last 90 days</span>
               {% endif %}
             {% else %}
               {{ get_value(model, c) }}

--- a/spkrepo/views/tasks.py
+++ b/spkrepo/views/tasks.py
@@ -302,26 +302,6 @@ def upload_to_storage(self, build_id, build_label):
     }
 
 
-@celery.task(queue="ops")
-def refresh_download_counts():
-    """Refresh the package_download_counts materialized view.
-
-    Runs hourly via Celery beat. Uses CONCURRENTLY so the view remains
-    readable during the refresh with no locking. Requires the unique index
-    ix_package_download_counts_package_id to exist (created in migration
-    3f5664905242_add_package_download_counts_materialized_view).
-
-    Also call this task directly after bulk download imports or any operation
-    that significantly changes download_stat row counts.
-    """
-    if db.engine.dialect.name != "postgresql":
-        return
-    db.session.execute(
-        db.text("REFRESH MATERIALIZED VIEW CONCURRENTLY package_download_counts")
-    )
-    db.session.commit()
-
-
 @celery.task(bind=True, max_retries=3, default_retry_delay=10, queue="ops")
 def rehome_from_storage(self, build_id, build_label):
     """Download a build from Object Storage back to local disk for editing."""


### PR DESCRIPTION
## Summary

Simplify download count refresh by running it immediately after `ingest_logs` instead of waiting for an hourly Celery beat task.

## Changes

- **`spkrepo/cli.py`** — `ingest_logs()` now refreshes `package_download_counts` via `REFRESH MATERIALIZED VIEW CONCURRENTLY` after inserting download stats. Dialect-guarded for PostgreSQL.
- **`spkrepo/config.py`** — Removed the `beat_schedule` entry for `refresh-download-counts`.
- **`spkrepo/views/tasks.py`** — Removed the `refresh_download_counts()` Celery task (dead code).
- **`spkrepo/models.py`** — Updated `PackageDownloadCounts` docstring to reflect new refresh mechanism.
- **`docs/deployment.rst`** — Removed Celery beat from the architecture list and start commands, since there are no longer any scheduled tasks.

## Rationale

The `ingest_logs` CLI is the only path that populates `DownloadStat` data. Running the refresh inline means download counts and badges are current immediately after ingest, rather than waiting up to an hour for the scheduled task. Celery beat is no longer a required component.