### PR TITLE
fix: html validator warnings, whitespace control, and badge wording

### DIFF
--- a/spkrepo/app.py
+++ b/spkrepo/app.py
@@ -114,6 +114,10 @@ def create_app(config=None, register_blueprints=True, init_admin=True):
     if debug_toolbar is not None:
         debug_toolbar.init_app(app)
 
+    # Jinja2 whitespace control
+    app.jinja_env.trim_blocks = True
+    app.jinja_env.lstrip_blocks = True
+
     # Jinja2 filters
     register_filters(app)
 

--- a/spkrepo/templates/_wtfhelpers.html
+++ b/spkrepo/templates/_wtfhelpers.html
@@ -108,7 +108,6 @@
                     action="",
                     method="post",
                     extra_classes=None,
-                    role="form",
                     form_type="basic",
                     horizontal_columns=('lg', 2, 10),
                     enctype=None,
@@ -122,7 +121,6 @@
     {%- if form_type == "inline" %} form-inline{% endif -%}
   "
   {%- if enctype %} enctype="{{enctype}}"{% endif -%}
-  {%- if role %} role="{{role}}"{% endif -%}
   >
   {{ form.hidden_tag() }}
   {{ form_errors(form, hiddens='only') }}

--- a/spkrepo/templates/frontend/package.html
+++ b/spkrepo/templates/frontend/package.html
@@ -23,43 +23,43 @@
       </div>
       {% endif %}
 
-      {# Active installs badge — only shown when package has meaningful recent downloads #}
+      {# Active downloads badge — only shown when package has meaningful recent downloads #}
       {% if package.download_counts %}
         {% set n = package.download_counts.recent_download_count %}
         {% if n >= 100000 %}
           <p>
-            <span class="badge badge-dark badge-pill">100k+ installs</span>
-            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+            <span class="badge badge-dark badge-pill">100k+ downloads</span>
+            <small class="text-muted ml-1">in the last 90 days</small>
           </p>
         {% elif n >= 50000 %}
           <p>
-            <span class="badge badge-primary badge-pill">50k+ installs</span>
-            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+            <span class="badge badge-primary badge-pill">50k+ downloads</span>
+            <small class="text-muted ml-1">in the last 90 days</small>
           </p>
         {% elif n >= 25000 %}
           <p>
-            <span class="badge badge-primary badge-pill">25k+ installs</span>
-            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+            <span class="badge badge-primary badge-pill">25k+ downloads</span>
+            <small class="text-muted ml-1">in the last 90 days</small>
           </p>
         {% elif n >= 10000 %}
           <p>
-            <span class="badge badge-info badge-pill">10k+ installs</span>
-            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+            <span class="badge badge-info badge-pill">10k+ downloads</span>
+            <small class="text-muted ml-1">in the last 90 days</small>
           </p>
         {% elif n >= 5000 %}
           <p>
-            <span class="badge badge-success badge-pill">5k+ installs</span>
-            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+            <span class="badge badge-success badge-pill">5k+ downloads</span>
+            <small class="text-muted ml-1">in the last 90 days</small>
           </p>
         {% elif n >= 2500 %}
           <p>
-            <span class="badge badge-success badge-pill">2.5k+ installs</span>
-            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+            <span class="badge badge-success badge-pill">2.5k+ downloads</span>
+            <small class="text-muted ml-1">in the last 90 days</small>
           </p>
         {% elif n >= 1000 %}
           <p>
-            <span class="badge badge-secondary badge-pill">1k+ installs</span>
-            <small class="text-muted ml-1">based on downloads in the last 90 days</small>
+            <span class="badge badge-secondary badge-pill">1k+ downloads</span>
+            <small class="text-muted ml-1">in the last 90 days</small>
           </p>
         {% endif %}
       {% endif %}
@@ -67,7 +67,7 @@
       <p>{{ package.versions[-1].builds[0].descriptions['enu'].description }}</p>
       <div class="package-screenshots">
         {% for screenshot in package.screenshots %}
-        <img class="package-screenshot" src="{{ url_for('nas.data', path=screenshot.path) }}"/>&nbsp;
+        <img class="package-screenshot" src="{{ url_for('nas.data', path=screenshot.path) }}" alt="Screenshot">&nbsp;
         {% endfor %}
       </div>
       {% for version in package.versions|reverse %}
@@ -95,7 +95,7 @@
               {% endfor %}
             {% endif %}
           {% endfor %}
-          <br/>
+          <br>
         {% endfor %}
         </dd>
       </dl>

--- a/spkrepo/templates/frontend/packages.html
+++ b/spkrepo/templates/frontend/packages.html
@@ -2,23 +2,23 @@
 {% block title %}Packages - {{ super() }}{% endblock %}
 {% block content %}
 
-{% macro installs_badge(counts) %}
+{% macro downloads_badge(counts) %}
   {% if counts %}
     {% set n = counts.recent_download_count %}
     {% if n >= 100000 %}
-      <span class="badge badge-dark" title="Based on downloads in last 90 days">100k+ installs</span>
+      <span class="badge badge-dark" title="Based on downloads in last 90 days">100k+ downloads</span>
     {% elif n >= 50000 %}
-      <span class="badge badge-primary" title="Based on downloads in last 90 days">50k+ installs</span>
+      <span class="badge badge-primary" title="Based on downloads in last 90 days">50k+ downloads</span>
     {% elif n >= 25000 %}
-      <span class="badge badge-primary" title="Based on downloads in last 90 days">25k+ installs</span>
+      <span class="badge badge-primary" title="Based on downloads in last 90 days">25k+ downloads</span>
     {% elif n >= 10000 %}
-      <span class="badge badge-info" title="Based on downloads in last 90 days">10k+ installs</span>
+      <span class="badge badge-info" title="Based on downloads in last 90 days">10k+ downloads</span>
     {% elif n >= 5000 %}
-      <span class="badge badge-success" title="Based on downloads in last 90 days">5k+ installs</span>
+      <span class="badge badge-success" title="Based on downloads in last 90 days">5k+ downloads</span>
     {% elif n >= 2500 %}
-      <span class="badge badge-success" title="Based on downloads in last 90 days">2.5k+ installs</span>
+      <span class="badge badge-success" title="Based on downloads in last 90 days">2.5k+ downloads</span>
     {% elif n >= 1000 %}
-      <span class="badge badge-secondary" title="Based on downloads in last 90 days">1k+ installs</span>
+      <span class="badge badge-secondary" title="Based on downloads in last 90 days">1k+ downloads</span>
     {% endif %}
   {% endif %}
 {% endmacro %}
@@ -28,19 +28,18 @@
   <div class="d-flex{% if archived %}" style="opacity: 0.6;{% endif %}">
     <div class="flex-shrink-0 mr-3" style="width: 72px;">
       <a href="{{ url_for('frontend.package', name=version.package.name) }}">
-        <img src="{{ url_for('nas.data', path=version.icons['72'].path) }}" alt="Icon"
-             {% if archived %}style="filter: grayscale(60%);"{% endif %}>
+        <img src="{{ url_for('nas.data', path=version.icons['72'].path) }}" alt="Icon"{% if archived %} style="filter: grayscale(60%);"{% endif %}>
       </a>
     </div>
     <div class="flex-grow-1">
-      <h5>{{ version.displaynames['enu'].displayname }}
+      <h2 class="h5">{{ version.displaynames['enu'].displayname }}
         <small class="text-muted">v{{ version.version_string }}</small>
         {% if archived %}
           <span class="badge badge-secondary ml-1">Archived</span>
         {% endif %}
-      </h5>
+      </h2>
       {% if not archived %}
-        {{ installs_badge(version.package.download_counts) }}
+        {{ downloads_badge(version.package.download_counts) }}
       {% endif %}
       <div class="ellipsis package-description">
         <p>{{ version.builds[0].descriptions['enu'].description }}</p>
@@ -64,6 +63,7 @@
   {% endif %}
 {% endfor %}
 
+<h1 class="sr-only">Packages</h1>
 <div id="packages">
 
   {# ── Active packages ── #}
@@ -79,9 +79,9 @@
   {% if archived_versions %}
   <div class="row mt-5 mb-2">
     <div class="col-12">
-      <h4 class="text-muted">
+      <h1 class="h4 text-muted">
         <i class="bi bi-archive mr-2"></i>Archived Packages
-      </h4>
+      </h1>
       <p class="text-muted small">
         These packages are no longer in the active catalog and are not actively maintained.
       </p>

--- a/spkrepo/templates/layout.html
+++ b/spkrepo/templates/layout.html
@@ -82,7 +82,7 @@
     {% block content %}{% endblock %}
     </div>
 
-    <footer class="footer" role="contentinfo">
+    <footer class="footer">
       <div class="container">
         <p>Designed by Antoine Bertin.</p>
         <p>Maintained by <a href="https://github.com/orgs/SynoCommunity/people">SynoCommunity</a> with the help of <a href="https://github.com/SynoCommunity/spksrc/graphs/contributors">contributors</a>.</p>


### PR DESCRIPTION
## Summary

Fix HTML validator warnings across frontend templates, add Jinja2 whitespace control, and correct badge wording.

## Changes

### HTML validation and whitespace control

- Enable `TRIM_BLOCKS` and `LSTRIP_BLOCKS` in Jinja2 environment for cleaner rendered output
- Remove redundant `role="contentinfo"` on `<footer>` (implicit in HTML5)
- Remove redundant `role="form"` from `quick_form` macro (implicit on `<form>`)
- Remove trailing slashes from void elements (`<br/>` → `<br>`, `<img/>` → `<img>`)
- Add missing `alt="Screenshot"` to screenshot images

### Badge wording and heading hierarchy

- Rename badges from "installs" to "downloads" (badges track downloads, not installs)
- Shorten repetitive subtitle from "based on downloads in the last 90 days" to "in the last 90 days"
- Fix heading hierarchy: use `h1` for page/section titles and `h2` for package cards (sequential, no skipped levels)
- Add screen-reader-only `h1` heading to `/packages` page for document structure
- Fix orphaned closing bracket on conditional `<img>` attributes

## Files changed

| File | Changes |
|---|---|
| `spkrepo/app.py` | +3 lines — Jinja2 whitespace control config |
| `spkrepo/templates/layout.html` | Remove `role="contentinfo"` from `<footer>` |
| `spkrepo/templates/_wtfhelpers.html` | Remove `role` parameter from `quick_form` macro |
| `spkrepo/templates/frontend/package.html` | Void element fixes, alt text, badge wording |
| `spkrepo/templates/frontend/packages.html` | Badge wording, heading hierarchy, sr-only h1 |
