### PR TITLE
Fix unbounded worker memory growth in catalog/package queries

### DIFF
--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -76,10 +76,10 @@ def packages():
             .options(
                 db.joinedload(Version.package).joinedload(Package.download_counts),
                 db.joinedload(Version.package).undefer(Package.has_active_builds),
-                db.joinedload(Version.icons),
-                db.joinedload(Version.displaynames).joinedload(DisplayName.language),
-                db.joinedload(Version.builds)
-                .joinedload(Build.descriptions)
+                db.selectinload(Version.icons),
+                db.selectinload(Version.displaynames).joinedload(DisplayName.language),
+                db.selectinload(Version.builds)
+                .selectinload(Build.descriptions)
                 .joinedload(BuildDescription.language),
             )
             .join(
@@ -102,11 +102,11 @@ def package(name):
         Package.query.filter_by(name=name)
         .options(
             db.joinedload(Package.download_counts),
-            db.joinedload(Package.versions).joinedload(Version.icons),
-            db.joinedload(Package.versions).joinedload(Version.displaynames),
-            db.joinedload(Package.versions)
-            .joinedload(Version.builds)
-            .joinedload(Build.descriptions),
+            db.selectinload(Package.versions).selectinload(Version.icons),
+            db.selectinload(Package.versions).selectinload(Version.displaynames),
+            db.selectinload(Package.versions)
+            .selectinload(Version.builds)
+            .selectinload(Build.descriptions),
         )
         .first()
     )

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -121,16 +121,18 @@ def get_catalog(arch, build, major, language, beta):
     firmware_min_for_build = aliased(Firmware)
     latest_build = (
         Build.query.options(
-            db.joinedload(Build.architectures),
+            db.selectinload(Build.architectures),
             db.joinedload(Build.firmware_min),
             db.joinedload(Build.firmware_max),
             db.joinedload(Build.version).joinedload(Version.package),
-            db.joinedload(Build.version).joinedload(Version.icons),
+            db.joinedload(Build.version).selectinload(Version.icons),
             db.joinedload(Build.version)
-            .joinedload(Version.displaynames)
+            .selectinload(Version.displaynames)
             .joinedload(DisplayName.language),
-            db.joinedload(Build.descriptions).joinedload(BuildDescription.language),
-            db.joinedload(Build.version, Version.package, Package.screenshots),
+            db.selectinload(Build.descriptions).joinedload(BuildDescription.language),
+            db.joinedload(Build.version, Version.package).selectinload(
+                Package.screenshots
+            ),
             db.joinedload(Build.buildmanifest),
         )
         .join(Build.architectures)


### PR DESCRIPTION
## Problem

`app` worker RSS grows from ~150MB baseline to ~1GB+ over 24-48h, on a
4GB host with no swap. A worker restart resets it to baseline, then it
recurs — not a hard leak, but unbounded, reclaimable growth.

## Root cause

- `Build`/`Version`/`Package` have several one-to-many collections
  (`architectures`, `icons`, `displaynames`, `descriptions`,
  `screenshots`).
- `nas.get_catalog()` and two `frontend.py` routes eager-load **multiple
  of these collections at once via `joinedload`**, which SQL implements
  as a `LEFT JOIN` per collection — returning one row per *combination*
  of collection entries (Cartesian product), not one row per parent.
- `get_catalog()` is memoized on `(arch, build, major, language, beta)`.
  Real device traffic has enough combinatorial diversity that the cache
  hit rate is close to zero, so this expensive query effectively runs on
  nearly every request (~150+/hr from prod log sample).
- Ruled out: SQLAlchemy session leak (teardown hook confirmed working),
  upload/signing buffers (growth continues with zero uploads),
  downloads (streamed via `send_file`, not buffered).

## Changes

**`nas.py`** — `get_catalog()`: `joinedload` → `selectinload` for
`architectures`, `icons`, `displaynames`, `descriptions`, `screenshots`.
Many-to-one relationships (`firmware_min`, `firmware_max`, `version`,
`package`, `buildmanifest`) stay `joinedload`.

**`frontend.py`** — same `joinedload` → `selectinload` swap in
`/packages` and `/package/<name>` for consistency (lower traffic, same
bug pattern).

**`docker-compose.yml`**
- `MALLOC_ARENA_MAX: "2"` on the shared `x-spkrepo` anchor — reduces
  glibc malloc fragmentation from remaining large, variable-sized
  allocations (SPK parsing/signing).
- `--max-requests 500 --max-requests-jitter 50` on `app` — recycles
  workers periodically so any residual growth gets reclaimed
  automatically.
- `mem_limit: 1.5g` on `app` — safety net given no swap on host;
  `restart: unless-stopped` recovers cleanly if hit.

## Explicitly not changed

`-k gthread` was considered, not added. Traffic doesn't need it (low
volume, mostly not I/O-wait-bound), and more concurrent slots per worker
would let more large buffers coexist in one process — working against
this fix. Prefer a 3rd sync worker over threads if real queuing shows up.

## Testing

- Both files parse correctly; compose file validated.
- Manual `/nas/?...` request against dev with a seeded arch/build/language
  combo returned `200` with a well-formed catalog response (icons,
  screenshots, descriptions, beta fields all present, no
  missing/duplicated entries).
- An initial `422` traced to missing seed data (`x86_64` not in dev DB),
  not a code issue.

## Rollout

1. Build/publish new image, `docker compose up -d app` (not just
   `restart`, so compose changes apply).
2. Monitor worker RSS for 24-48h to confirm growth flattens.