### PR TITLE
perf: sort builds_per_dsm deterministically

### DIFF
--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -823,12 +823,32 @@ class Version(db.Model):
 
     @property
     def builds_per_dsm(self):
-        result = {}
-        for build in self.builds:
-            result.setdefault(build.firmware_min.version.split(".")[0], []).append(
-                build
+        """Group builds by DSM/SRM major version, newest-first, with each
+        group's builds also ordered by full firmware version, newest-first,
+        so e.g. 7.2.x builds don't interleave with 7.1.x builds.
+        """
+
+        def _firmware_sort_key(build):
+            return tuple(
+                int(part) if part.isdigit() else part
+                for part in build.firmware_min.version.split(".")
             )
-        return result
+
+        groups = {}
+        for build in self.builds:
+            major = build.firmware_min.version.split(".")[0]
+            groups.setdefault(major, []).append(build)
+
+        for builds in groups.values():
+            builds.sort(key=_firmware_sort_key, reverse=True)
+
+        return dict(
+            sorted(
+                groups.items(),
+                key=lambda item: int(item[0]) if item[0].isdigit() else item[0],
+                reverse=True,
+            )
+        )
 
     @hybrid_property
     def total_size(self):


### PR DESCRIPTION
## Summary

The `Version.builds_per_dsm` property previously returned builds in whatever order they happened to be loaded from the database, which was unpredictable. This change makes the ordering deterministic and user-friendly.

## Changes

**`spkrepo/models.py`** — `Version.builds_per_dsm` property

- Major version groups are sorted **newest-first** (DSM 7 → DSM 6 → SRM 1)
- Builds within each group are sorted by their full firmware version, **newest-first** (e.g., 7.2.x before 7.1.x)
- Version strings are parsed as integers for correct numeric sorting ("10" > "9")
- Result is an ordered dict preserving the sort order

Before (insertion-order from DB, unpredictable):
```
DSM 6: 6.1, 6.2
DSM 7: 7.0, 7.1, 7.2
```

After (newest-first, deterministic):
```
DSM 7: 7.2, 7.1, 7.0
DSM 6: 6.2, 6.1
```
