### PR TITLE
docs: add model docstrings and CLI reference; refactor: modernize SQLAlchemy queries to 2.0 style

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -42,6 +42,7 @@ Available actions appear in the dropdown after selecting items in a list view.
 
 **04 Rehome (Versions / Builds)**
     Downloads a build from object storage back to local disk for editing.
+    Build must be inactive and in Object Storage.
 
 **05 Resync Info (Versions / Builds)**
     Re-reads metadata (changelog, description, icons) from the local SPK file.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,33 @@
+CLI Commands
+============
+
+Run via ``flask spkrepo <command>`` inside the app's environment.
+
+Commands
+--------
+
+**create_user**
+    Create a new user with an activated account.
+
+    Options: ``-u/--username``, ``-e/--email``, ``-p/--password``
+    (all prompted if omitted).
+
+**create_admin**
+    Create a new super admin user, assigning the ``admin``,
+    ``package_admin``, and ``developer`` roles. Skips user creation if a
+    user with the given email already exists.
+
+    Options: ``-u/--username`` (default ``admin``), ``-e/--email``
+    (default ``admin@synocommunity.com``), ``-p/--password`` (prompted).
+
+**populate_db**
+    Populate the database with sample packages, for local development.
+
+**depopulate_db**
+    Delete all packages from the database and file system. Refuses to
+    run if any build has been uploaded to Object Storage.
+
+**ingest_logs**
+    Ingest download stats from Object Storage log files and refresh the
+    download-count materialized view. Runs hourly via the ``ingest``
+    container — see :doc:`operations`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,8 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinxcontrib.httpdomain",
     "sphinxcontrib.autohttp.flask",
+    # Needed so @celery.task-decorated functions in tasks.py get autodoc'd.
+    "celery.contrib.sphinx",
 ]
 
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ and comes with an API, advanced permission management and an admin interface.
    utils
    operations
    admin
+   cli
    migrations
 
 .. toctree::

--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -211,34 +211,33 @@ def depopulate_db():
 
 @spkrepo.command("create_admin")
 @click.option("-u", "--username", prompt=True, default="admin", help="username")
-@click.option("-e", "--email", prompt=True, default="admin@synocommunity.com", help="email")
+@click.option(
+    "-e", "--email", prompt=True, default="admin@synocommunity.com", help="email"
+)
 @click.option("-p", "--password", prompt=True, hide_input=True, help="password")
 @with_appcontext
 def create_admin(username, email, password):
     """Create a new super admin user."""
-    click.echo("Creating admin user…")
-    existing_admin = (
+    existing_user = (
         db.session.execute(db.select(User).filter_by(email=email)).scalars().first()
     )
-    if existing_admin:
-        click.echo(f"'{username}' user already exists, skipping creation")
-    else:
-        _create_user(
-            username=username,
-            email=email,
-            password=password,
-        )
+    if existing_user:
+        click.echo(f"User '{username}' already exists. No changes made.")
+        return
+
+    click.echo("Creating admin user…")
+    _create_user(
+        username=username,
+        email=email,
+        password=password,
+    )
 
     user = db.session.execute(db.select(User).filter_by(email=email)).scalars().first()
     if not user:
         raise ValueError(f"No user with email {email}")
 
     for role_name in ("admin", "package_admin", "developer"):
-        role = (
-            db.session.execute(db.select(Role).filter_by(name=role_name))
-            .scalars()
-            .first()
-        )
+        role = Role.find(role_name)
         if not role:
             raise ValueError(f"No role with name '{role_name}'")
 

--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -191,10 +191,14 @@ def populate_db():
 @with_appcontext
 def depopulate_db():
     """Delete all packages from database and file system."""
-    if db.session.query(Build).filter(Build.storage != "local").first():
+    if (
+        db.session.execute(db.select(Build).filter(Build.storage != "local"))
+        .scalars()
+        .first()
+    ):
         click.echo("Refusing: builds in Object Storage. Use local-only DB.")
         return
-    for package in Package.query.all():
+    for package in db.session.execute(db.select(Package)).scalars().all():
         db.session.delete(package)
         shutil.rmtree(
             os.path.join(current_app.config["DATA_PATH"], package.name),
@@ -213,7 +217,9 @@ def depopulate_db():
 def create_admin(username, email, password):
     """Create a new super admin user."""
     click.echo("Creating admin user…")
-    existing_admin = User.query.filter_by(email=email).first()
+    existing_admin = (
+        db.session.execute(db.select(User).filter_by(email=email)).scalars().first()
+    )
     if existing_admin:
         click.echo(f"'{username}' user already exists, skipping creation")
     else:
@@ -223,12 +229,16 @@ def create_admin(username, email, password):
             password=password,
         )
 
-    user = User.query.filter_by(email=email).first()
+    user = db.session.execute(db.select(User).filter_by(email=email)).scalars().first()
     if not user:
         raise ValueError(f"No user with email {email}")
 
     for role_name in ("admin", "package_admin", "developer"):
-        role = Role.query.filter_by(name=role_name).first()
+        role = (
+            db.session.execute(db.select(Role).filter_by(name=role_name))
+            .scalars()
+            .first()
+        )
         if not role:
             raise ValueError(f"No role with name '{role_name}'")
 
@@ -244,7 +254,11 @@ def create_admin(username, email, password):
 @with_appcontext
 def clean():
     """Clean data path, removes all packages on filesystem."""
-    if db.session.query(Build).filter(Build.storage != "local").first():
+    if (
+        db.session.execute(db.select(Build).filter(Build.storage != "local"))
+        .scalars()
+        .first()
+    ):
         click.echo("Refusing: builds in Object Storage. Use local-only DB.")
         return
     # do not remove and recreate the path since it may be a docker volume
@@ -397,7 +411,11 @@ def ingest_logs():
 
                 if url_path not in build_cache:
                     build = (
-                        db.session.query(Build).filter(Build.path == url_path).first()
+                        db.session.execute(
+                            db.select(Build).filter(Build.path == url_path)
+                        )
+                        .scalars()
+                        .first()
                     )
                     if build:
                         build_cache[url_path] = (build.id, build.version.package_id)

--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -210,8 +210,8 @@ def depopulate_db():
 
 
 @spkrepo.command("create_admin")
-@click.option("-u", "--username", default="admin", help="username")
-@click.option("-e", "--email", default="admin@synocommunity.com", help="email")
+@click.option("-u", "--username", prompt=True, default="admin", help="username")
+@click.option("-e", "--email", prompt=True, default="admin@synocommunity.com", help="email")
 @click.option("-p", "--password", prompt=True, hide_input=True, help="password")
 @with_appcontext
 def create_admin(username, email, password):

--- a/spkrepo/models.py
+++ b/spkrepo/models.py
@@ -65,6 +65,9 @@ def _utcnow():
 
 
 class User(db.Model, UserMixin):
+    """A registered user, including authentication credentials and their
+    authored/maintained package relationships."""
+
     __tablename__ = "user"
 
     # Columns
@@ -95,6 +98,9 @@ class User(db.Model, UserMixin):
 
 
 class Role(db.Model, RoleMixin):
+    """A named permission role (e.g. admin, developer, package_admin)
+    assignable to users."""
+
     __tablename__ = "role"
 
     # Columns
@@ -107,6 +113,7 @@ class Role(db.Model, RoleMixin):
 
     @classmethod
     def find(cls, name):
+        """Look up a role by its name, or return None if not found."""
         return (
             db.session.execute(select(cls).filter(cls.name == name)).scalars().first()
         )
@@ -122,6 +129,9 @@ user_datastore = SQLAlchemyUserDatastore(db, User, Role)
 
 
 class Architecture(db.Model):
+    """A supported NAS CPU architecture (e.g. x86_64, apollolake) that a
+    build can target."""
+
     __tablename__ = "architecture"
 
     __table_args__ = (db.Index("ix_architecture_id_code", "id", "code"),)
@@ -141,6 +151,9 @@ class Architecture(db.Model):
 
     @classmethod
     def find(cls, code, syno=False):
+        """Look up an architecture by its code, or return None if not
+        found. If syno=True, code is first translated from its Synology
+        DSM/SRM spelling (e.g. "88f6281") to its canonical form."""
         if syno:
             code = _ARCH_FROM_SYNO.get(code, code)
         return (
@@ -155,6 +168,9 @@ class Architecture(db.Model):
 
 
 class Language(db.Model):
+    """A supported language/locale code (e.g. enu, chs) used for version
+    display names and build descriptions."""
+
     __tablename__ = "language"
 
     # Columns
@@ -164,6 +180,7 @@ class Language(db.Model):
 
     @classmethod
     def find(cls, code):
+        """Look up a language by its code, or return None if not found."""
         return (
             db.session.execute(select(cls).filter(cls.code == code)).scalars().first()
         )
@@ -176,6 +193,9 @@ class Language(db.Model):
 
 
 class Firmware(db.Model):
+    """A specific DSM/SRM firmware release, identified by its build
+    number, used to define a build's supported firmware range."""
+
     __tablename__ = "firmware"
 
     __table_args__ = (
@@ -200,12 +220,15 @@ class Firmware(db.Model):
 
     @classmethod
     def find(cls, build):
+        """Look up a firmware by its build number, or return None if not
+        found."""
         return (
             db.session.execute(select(cls).filter(cls.build == build)).scalars().first()
         )
 
     @property
     def firmware_string(self):
+        """Combined "version-build" string, e.g. "7.2-64570"."""
         return f"{self.version}-{self.build}"
 
     def __str__(self):
@@ -216,6 +239,8 @@ class Firmware(db.Model):
 
 
 class Screenshot(db.Model):
+    """A package screenshot image, stored on disk under DATA_PATH."""
+
     __tablename__ = "screenshot"
 
     # Columns
@@ -229,6 +254,8 @@ class Screenshot(db.Model):
     package = db.relationship("Package", back_populates="screenshots")
 
     def save(self, stream):
+        """Write the given binary stream to this screenshot's file on
+        disk at self.path."""
         with io.open(
             os.path.join(current_app.config["DATA_PATH"], self.path), "wb"
         ) as f:
@@ -252,6 +279,9 @@ class Screenshot(db.Model):
 
 
 class Icon(db.Model):
+    """A package icon image at a specific size (72/120/256px), stored on
+    disk under DATA_PATH."""
+
     __tablename__ = "icon"
 
     # Columns
@@ -267,6 +297,8 @@ class Icon(db.Model):
     version = db.relationship("Version", back_populates="icons")
 
     def save(self, stream):
+        """Write the given binary stream to this icon's file on disk at
+        self.path."""
         with io.open(
             os.path.join(current_app.config["DATA_PATH"], self.path), "wb"
         ) as f:
@@ -290,6 +322,9 @@ class Icon(db.Model):
 
 
 class Service(db.Model):
+    """A named system service that a version can declare as an
+    install-time dependency (INFO's install_dep_services)."""
+
     __tablename__ = "service"
 
     # Columns
@@ -298,6 +333,7 @@ class Service(db.Model):
 
     @classmethod
     def find(cls, code):
+        """Look up a service by its code, or return None if not found."""
         return (
             db.session.execute(select(cls).filter(cls.code == code)).scalars().first()
         )
@@ -310,6 +346,8 @@ class Service(db.Model):
 
 
 class DisplayName(db.Model):
+    """A version's localized display name for a single language."""
+
     __tablename__ = "displayname"
 
     # Columns
@@ -331,6 +369,8 @@ class DisplayName(db.Model):
 
 
 class BuildDescription(db.Model):
+    """A build's localized description text for a single language."""
+
     __tablename__ = "build_description"
 
     # Columns
@@ -359,6 +399,10 @@ version_service_dependency = db.Table(
 
 
 class DownloadStat(db.Model):
+    """A single day's download count for a package, optionally broken
+    down by build, architecture, and/or firmware. Aggregated into
+    PackageDownloadCounts via a materialized view refresh."""
+
     __tablename__ = "download_stat"
 
     # Columns
@@ -451,6 +495,9 @@ build_architecture = db.Table(
 
 
 class Build(db.Model):
+    """A single compiled package artifact for one Version, targeting a
+    specific firmware range and set of architectures."""
+
     __tablename__ = "build"
 
     # Columns
@@ -517,20 +564,28 @@ class Build(db.Model):
 
     @classmethod
     def generate_filename(cls, package, version, firmware, architectures):
-        """
-        Backward-compatible signature.
-        Pass the intended firmware (typically firmware_min) from the caller.
+        """Build a Build's .spk filename from its constituent parts.
+
+        Takes package/version/firmware/architectures explicitly, rather
+        than reading them off an instance, because callers need the
+        filename to construct Build.path *before* the Build itself
+        exists (see api.py's upload handler). Pass the intended firmware
+        (typically firmware_min).
         """
         arch_codes = "-".join(a.code for a in architectures)
         return f"{package.name}.v{version.version}.f{firmware.build}[{arch_codes}].spk"
 
     def save(self, stream):
+        """Write the given binary stream to this build's file on disk at
+        self.path."""
         with io.open(
             os.path.join(current_app.config["DATA_PATH"], self.path), "wb"
         ) as f:
             f.write(stream.read())
 
     def calculate_md5(self):
+        """Compute and return this build's file's MD5 checksum by reading
+        it from disk in chunks."""
         if not self.path:
             raise ValueError("Path cannot be empty.")
         file_path = os.path.join(current_app.config["DATA_PATH"], self.path)
@@ -543,23 +598,13 @@ class Build(db.Model):
             return md5_hash.hexdigest()
 
     def calculate_size(self):
+        """Return this build's file size in bytes, read from disk."""
         if not self.path:
             raise ValueError("Path cannot be empty.")
         file_path = os.path.join(current_app.config["DATA_PATH"], self.path)
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found at path: {file_path}")
         return os.path.getsize(file_path)
-
-    @property
-    def storage_location(self):
-        """Returns 'remote', 'local', or 'missing' based on filesystem."""
-        sidecar = os.path.join(current_app.config["DATA_PATH"], self.path + ".json")
-        local = os.path.join(current_app.config["DATA_PATH"], self.path)
-        if os.path.exists(sidecar):
-            return "remote"
-        if os.path.exists(local):
-            return "local"
-        return "missing"
 
     def _before_insert(self):
         self._insert_path = os.path.join(current_app.config["DATA_PATH"], self.path)
@@ -694,6 +739,9 @@ Firmware.recent_target_download_count = db.column_property(
 
 
 class BuildManifest(db.Model):
+    """A build's install-time dependency/conflict/permission manifest,
+    parsed from its SPK INFO/conf files."""
+
     __tablename__ = "buildmanifest"
 
     # Columns
@@ -716,6 +764,9 @@ class BuildManifest(db.Model):
 
 
 class Version(db.Model):
+    """A single released version of a package, grouping one or more
+    architecture/firmware-specific Builds."""
+
     __tablename__ = "version"
 
     # Columns
@@ -765,6 +816,8 @@ class Version(db.Model):
 
     @hybrid_property
     def beta(self):
+        """True if this version has a report_url set, marking it as a
+        beta/testing release."""
         return bool(self.report_url)  # Treats None and "" as False
 
     @beta.expression
@@ -773,6 +826,7 @@ class Version(db.Model):
 
     @hybrid_property
     def all_builds_active(self):
+        """True if every build of this version is marked active."""
         return all(b.active for b in self.builds)
 
     @all_builds_active.expression
@@ -783,6 +837,8 @@ class Version(db.Model):
 
     @hybrid_property
     def all_builds_uploaded(self):
+        """True if every build of this version has been uploaded to
+        remote storage."""
         return all(b.storage == "remote" for b in self.builds)
 
     @all_builds_uploaded.expression
@@ -793,10 +849,12 @@ class Version(db.Model):
 
     @property
     def path(self):
+        """This version's directory path on disk, relative to DATA_PATH."""
         return os.path.join(self.package.name, str(self.version))
 
     @property
     def version_string(self):
+        """Combined "upstream_version-version" string, e.g. "1.4.103-10"."""
         return self.upstream_version + "-" + str(self.version)
 
     def _before_insert(self):
@@ -852,6 +910,8 @@ class Version(db.Model):
 
     @hybrid_property
     def total_size(self):
+        """Combined file size in bytes across all builds with a known
+        size, or None if no build has one."""
         # Returns None if no builds have a known size, rather than 0
         total = sum(b.size for b in self.builds if b.size is not None)
         return total or None
@@ -891,6 +951,8 @@ Version.recent_download_count = db.column_property(
 
 
 class Package(db.Model):
+    """A SynoCommunity package, grouping all of its released Versions."""
+
     __tablename__ = "package"
 
     # Columns
@@ -970,6 +1032,7 @@ class Package(db.Model):
 
     @classmethod
     def find(cls, name):
+        """Look up a package by its name, or return None if not found."""
         return (
             db.session.execute(select(cls).filter(cls.name == name)).scalars().first()
         )

--- a/spkrepo/tests/common.py
+++ b/spkrepo/tests/common.py
@@ -50,18 +50,27 @@ fake = faker.Faker()
 class QueryFactory(factory.DictFactory):
     timezone = fake.timezone().split("/")[1]
     language = factory.LazyAttribute(
-        lambda x: random.choice([language.code for language in Language.query.all()])
+        lambda x: random.choice(
+            [
+                language.code
+                for language in db.session.execute(db.select(Language)).scalars()
+            ]
+        )
     )
     arch = factory.LazyAttribute(
         lambda x: random.choice(
             [
                 Architecture.to_syno.get(a.code, a.code)
-                for a in Architecture.query.filter(Architecture.code != "noarch").all()
+                for a in db.session.execute(
+                    db.select(Architecture).filter(Architecture.code != "noarch")
+                ).scalars()
             ]
         )
     )
     build = factory.LazyAttribute(
-        lambda x: random.choice([f.build for f in Firmware.query.all()])
+        lambda x: random.choice(
+            [f.build for f in db.session.execute(db.select(Firmware)).scalars()]
+        )
     )
     major = factory.LazyAttribute(
         lambda x: int(Firmware.find(x.build).version.split(".")[0])
@@ -186,7 +195,9 @@ class VersionFactory(SQLAlchemyModelFactory):
     startable = None
     license = factory.LazyAttribute(lambda x: fake.text())
     service_dependencies = factory.LazyAttribute(
-        lambda x: [random.choice(Service.query.all())]
+        lambda x: [
+            random.choice(db.session.execute(db.select(Service)).scalars().all())
+        ]
     )
 
     @factory.post_generation
@@ -230,13 +241,19 @@ class BuildFactory(SQLAlchemyModelFactory):
         model = Build
 
     version = factory.SubFactory(VersionFactory)
-    firmware_min = factory.LazyAttribute(lambda x: random.choice(Firmware.query.all()))
+    firmware_min = factory.LazyAttribute(
+        lambda x: random.choice(db.session.execute(db.select(Firmware)).scalars().all())
+    )
     firmware_max = None
     changelog = factory.LazyAttribute(lambda x: fake.sentence())
     architectures = factory.LazyAttribute(
         lambda x: [
             random.choice(
-                Architecture.query.filter(Architecture.code != "noarch").all()
+                db.session.execute(
+                    db.select(Architecture).filter(Architecture.code != "noarch")
+                )
+                .scalars()
+                .all()
             )
         ]
     )
@@ -310,8 +327,12 @@ class BuildFactory(SQLAlchemyModelFactory):
             and "architectures" not in kwargs
         ):
             combinations = itertools.product(
-                Firmware.query.all(),
-                Architecture.query.filter(Architecture.code != "noarch").all(),
+                db.session.execute(db.select(Firmware)).scalars().all(),
+                db.session.execute(
+                    db.select(Architecture).filter(Architecture.code != "noarch")
+                )
+                .scalars()
+                .all(),
             )
             batch = []
             for _ in range(size):
@@ -336,7 +357,9 @@ class DownloadStatFactory(SQLAlchemyModelFactory):
     build = factory.SubFactory(BuildFactory)
     architecture = factory.LazyAttribute(lambda x: x.build.architectures[0])
     firmware_build = factory.LazyAttribute(
-        lambda x: random.choice([f.build for f in Firmware.query.all()])
+        lambda x: random.choice(
+            [f.build for f in db.session.execute(db.select(Firmware)).scalars()]
+        )
     )
     date = factory.LazyAttribute(lambda x: fake.date_this_month())
     count = factory.LazyAttribute(lambda x: random.randint(1, 1000))
@@ -380,7 +403,11 @@ class BaseTestCase(TestCase):
 
     def create_user(self, *args, **kwargs):
         user = UserFactory(
-            roles=[Role.query.filter_by(name=role).one() for role in args], **kwargs
+            roles=[
+                db.session.execute(db.select(Role).filter_by(name=role)).scalars().one()
+                for role in args
+            ],
+            **kwargs,
         )
         db.session.commit()
         return user

--- a/spkrepo/tests/test_admin_actions.py
+++ b/spkrepo/tests/test_admin_actions.py
@@ -349,14 +349,14 @@ class VersionTestCase(_AdminActionTestMixin, BaseTestCase):
     def test_on_model_delete(self):
         version = VersionFactory()
         db.session.commit()
-        self.assertEqual(len(Version.query.all()), 1)
+        self.assertEqual(len(db.session.execute(db.select(Version)).scalars().all()), 1)
         version_path = os.path.join(
             current_app.config["DATA_PATH"], version.package.name, str(version.version)
         )
         self.assertTrue(os.path.exists(version_path))
         with self.logged_user("package_admin", "admin"):
             self.client.post(url_for("version.delete_view", id=str(version.id)))
-        self.assertEqual(len(Version.query.all()), 0)
+        self.assertEqual(len(db.session.execute(db.select(Version)).scalars().all()), 0)
         self.assertTrue(not os.path.exists(version_path))
 
     def test_action_resync_info_visible_to_package_admin(self):
@@ -425,8 +425,16 @@ class VersionTestCase(_AdminActionTestMixin, BaseTestCase):
 
     def test_action_resync_info_refreshes_build_metadata(self):
         build = BuildFactory(
-            firmware_min=Firmware.query.order_by(Firmware.build.asc()).first(),
-            firmware_max=Firmware.query.order_by(Firmware.build.desc()).first(),
+            firmware_min=db.session.execute(
+                db.select(Firmware).order_by(Firmware.build.asc())
+            )
+            .scalars()
+            .first(),
+            firmware_max=db.session.execute(
+                db.select(Firmware).order_by(Firmware.build.desc())
+            )
+            .scalars()
+            .first(),
         )
         db.session.commit()
 
@@ -437,9 +445,13 @@ class VersionTestCase(_AdminActionTestMixin, BaseTestCase):
         original_dependencies = build.buildmanifest.dependencies
         original_conf_privilege = build.buildmanifest.conf_privilege
 
-        corrupting_firmware = Firmware.query.filter(
-            Firmware.id != original_firmware_min.id
-        ).first()
+        corrupting_firmware = (
+            db.session.execute(
+                db.select(Firmware).filter(Firmware.id != original_firmware_min.id)
+            )
+            .scalars()
+            .first()
+        )
         self.assertIsNotNone(corrupting_firmware, "Need at least 2 firmware entries")
         build.firmware_min = corrupting_firmware
         build.firmware_max = None

--- a/spkrepo/tests/test_admin_core.py
+++ b/spkrepo/tests/test_admin_core.py
@@ -68,23 +68,23 @@ class PackageTestCase(BaseTestCase):
             self.assert403(self.client.get(url_for("package.index_view")))
 
     def test_on_model_create(self):
-        self.assertEqual(len(Package.query.all()), 0)
+        self.assertEqual(len(db.session.execute(db.select(Package)).scalars().all()), 0)
         with self.logged_user("package_admin"):
             self.client.post(url_for("package.create_view"), data=dict(name="test"))
-        self.assertEqual(len(Package.query.all()), 1)
-        package = Package.query.one()
+        self.assertEqual(len(db.session.execute(db.select(Package)).scalars().all()), 1)
+        package = db.session.execute(db.select(Package)).scalars().one()
         package_path = os.path.join(current_app.config["DATA_PATH"], package.name)
         self.assertTrue(os.path.exists(package_path))
 
     def test_on_model_delete(self):
         package = PackageFactory()
         db.session.commit()
-        self.assertEqual(len(Package.query.all()), 1)
+        self.assertEqual(len(db.session.execute(db.select(Package)).scalars().all()), 1)
         package_path = os.path.join(current_app.config["DATA_PATH"], package.name)
         self.assertTrue(os.path.exists(package_path))
         with self.logged_user("package_admin", "admin"):
             self.client.post(url_for("package.delete_view", id=str(package.id)))
-        self.assertEqual(len(Package.query.all()), 0)
+        self.assertEqual(len(db.session.execute(db.select(Package)).scalars().all()), 0)
         self.assertTrue(not os.path.exists(package_path))
 
 

--- a/spkrepo/tests/test_api.py
+++ b/spkrepo/tests/test_api.py
@@ -21,6 +21,11 @@ from spkrepo.tests.common import (
 )
 
 
+def get_only_build():
+    """Return the single Build row expected to exist after a test upload."""
+    return db.session.execute(db.select(Build)).unique().scalars().one()
+
+
 def authorization_header(user):
     auth_str = user.api_key + ":"
     encoded_auth = base64.b64encode(auth_str.encode("utf-8")).decode("ascii")
@@ -179,7 +184,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_conflict(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -214,7 +219,11 @@ class PackagesTestCase(BaseTestCase):
         # Pin to the lowest seeded firmware so newer_firmware is always strictly higher.
         base_build = BuildFactory.build(
             architectures=[Architecture.find("noarch")],
-            firmware_min=Firmware.query.order_by(Firmware.build.asc()).first(),
+            firmware_min=db.session.execute(
+                db.select(Firmware).order_by(Firmware.build.asc())
+            )
+            .scalars()
+            .first(),
         )
         with (
             create_spk(base_build) as spk,
@@ -238,7 +247,11 @@ class PackagesTestCase(BaseTestCase):
 
         # Always use the highest seeded firmware to guarantee it is genuinely newer
         # than whatever the factory picked for base_build, avoiding a flaky fixture.
-        newer_firmware = Firmware.query.order_by(Firmware.build.desc()).first()
+        newer_firmware = (
+            db.session.execute(db.select(Firmware).order_by(Firmware.build.desc()))
+            .scalars()
+            .first()
+        )
         self.assertIsNotNone(newer_firmware)
         self.assertGreater(
             newer_firmware.build,
@@ -376,7 +389,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_icons_in_both(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -391,7 +404,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_no_license(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -406,7 +419,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_install_wizard(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -421,7 +434,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_upgrade_wizard(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -436,7 +449,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_120_icon(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -453,7 +466,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_startable(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -468,7 +481,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_not_startable(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -483,7 +496,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_wrong_displayname_language(self):
         user = UserFactory(roles=[Role.find("developer"), Role.find("package_admin")])
@@ -645,7 +658,7 @@ class PackagesTestCase(BaseTestCase):
             )
 
         # Fetch the persisted version from the DB.
-        persisted_version = Build.query.one().version
+        persisted_version = get_only_build().version
         existing_displayname = persisted_version.displaynames["enu"].displayname
 
         # Second build: different arch to avoid conflict, modified displayname.
@@ -667,7 +680,7 @@ class PackagesTestCase(BaseTestCase):
 
         db.session.expire_all()
         self.assertEqual(
-            Build.query.one().version.displaynames["enu"].displayname,
+            get_only_build().version.displaynames["enu"].displayname,
             existing_displayname,
         )
 
@@ -690,7 +703,7 @@ class PackagesTestCase(BaseTestCase):
                 )
             )
 
-        persisted_build = Build.query.one()
+        persisted_build = get_only_build()
         existing_changelog = persisted_build.changelog or ""
 
         new_build = BuildFactory.build(
@@ -727,7 +740,7 @@ class PackagesTestCase(BaseTestCase):
                 )
             )
 
-        persisted_build = Build.query.one()
+        persisted_build = get_only_build()
         existing_description = persisted_build.descriptions["enu"].description
 
         new_build = BuildFactory.build(
@@ -785,7 +798,7 @@ class PackagesTestCase(BaseTestCase):
                     data=spk.read(),
                 )
             )
-        self.assertBuildInserted(Build.query.one(), build, user)
+        self.assertBuildInserted(get_only_build(), build, user)
 
     def test_post_invalid_firmware_max(self):
         # os_max_ver that doesn't match the firmware regex returns 422.

--- a/spkrepo/tests/test_nas.py
+++ b/spkrepo/tests/test_nas.py
@@ -243,18 +243,16 @@ class CatalogTestCase(BaseTestCase):
         # Populate the package_download_counts materialized view used by
         # the catalog, matching what the production Celery task does.
         ninety_days_ago = datetime.now().date() - timedelta(days=90)
-        total = (
-            db.session.query(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
-            .filter(DownloadStat.package_id == package.id)
-            .scalar()
+        total = db.session.scalar(
+            db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0)).filter(
+                DownloadStat.package_id == package.id
+            )
         )
-        recent = (
-            db.session.query(db.func.coalesce(db.func.sum(DownloadStat.count), 0))
-            .filter(
+        recent = db.session.scalar(
+            db.select(db.func.coalesce(db.func.sum(DownloadStat.count), 0)).filter(
                 DownloadStat.package_id == package.id,
                 DownloadStat.date >= ninety_days_ago,
             )
-            .scalar()
         )
         db.session.add(
             PackageDownloadCounts(

--- a/spkrepo/tests/test_utils.py
+++ b/spkrepo/tests/test_utils.py
@@ -24,9 +24,10 @@ from spkrepo.utils import (
 
 class SPKParseTestCase(BaseTestCase):
     def test_generic(self):
+        architectures = db.session.execute(db.select(Architecture)).scalars().all()
         build = BuildFactory.build(
             version__upgrade_wizard=True,
-            architectures=[Architecture.query.all()[0], Architecture.query.all()[1]],
+            architectures=[architectures[0], architectures[1]],
         )
         with create_spk(build, signature="signature") as f:
             spk = SPK(f)

--- a/spkrepo/utils.py
+++ b/spkrepo/utils.py
@@ -540,8 +540,11 @@ def assert_version_metadata_matches_db(version, spk):
 
 def apply_info_from_spk(session, build, spk, md5_hash):
     """Apply all metadata from a parsed SPK onto the given build and its parent
-    version. This is the single source of truth for writing SPK metadata to the
-    database, used by both the upload path (api.py) and the resync path (admin.py).
+    version. Used by the resync path (tasks.py's resync_build_metadata,
+    triggered from admin.py). NOT currently used by the upload path
+    (api.py's Packages.post), which has its own separate, inline
+    implementation of similar logic for creating new Package/Version/Build
+    records — see that function if you need to keep both in sync.
 
     Version-level fields (shared across all builds of a version) are written
     unconditionally — callers must ensure consistency has already been checked

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -1448,26 +1448,52 @@ class IndexView(AdminIndexView):
             return q.join(Package.maintainers).filter(User.id == current_user.id)
 
         if is_privileged:
-            package_count = Package.query.count()
-            build_count = Build.query.count()
-            inactive_build_count = Build.query.filter_by(active=False).count()
+            package_count = db.session.scalar(
+                db.select(db.func.count()).select_from(Package)
+            )
+            build_count = db.session.scalar(
+                db.select(db.func.count()).select_from(Build)
+            )
+            inactive_build_count = db.session.scalar(
+                db.select(db.func.count()).select_from(Build).filter_by(active=False)
+            )
             recent_versions = (
-                Version.query.order_by(Version.insert_date.desc()).limit(5).all()
+                db.session.execute(
+                    db.select(Version).order_by(Version.insert_date.desc()).limit(5)
+                )
+                .scalars()
+                .all()
             )
         else:
-            package_count = _maintainer_filter(Package.query).count()
-            build_count = _maintainer_filter(
-                Build.query.join(Build.version).join(Version.package)
-            ).count()
-            inactive_build_count = _maintainer_filter(
-                Build.query.filter_by(active=False)
-                .join(Build.version)
-                .join(Version.package)
-            ).count()
+            package_count = db.session.scalar(
+                db.select(db.func.count()).select_from(
+                    _maintainer_filter(db.select(Package)).subquery()
+                )
+            )
+            build_count = db.session.scalar(
+                db.select(db.func.count()).select_from(
+                    _maintainer_filter(
+                        db.select(Build).join(Build.version).join(Version.package)
+                    ).subquery()
+                )
+            )
+            inactive_build_count = db.session.scalar(
+                db.select(db.func.count()).select_from(
+                    _maintainer_filter(
+                        db.select(Build)
+                        .filter_by(active=False)
+                        .join(Build.version)
+                        .join(Version.package)
+                    ).subquery()
+                )
+            )
             recent_versions = (
-                _maintainer_filter(Version.query.join(Version.package))
-                .order_by(Version.insert_date.desc())
-                .limit(5)
+                db.session.execute(
+                    _maintainer_filter(db.select(Version).join(Version.package))
+                    .order_by(Version.insert_date.desc())
+                    .limit(5)
+                )
+                .scalars()
                 .all()
             )
 
@@ -1497,7 +1523,11 @@ class IndexView(AdminIndexView):
             build_count=build_count,
             inactive_build_count=inactive_build_count,
             unconfirmed_user_count=(
-                User.query.filter_by(confirmed_at=None).count()
+                db.session.scalar(
+                    db.select(db.func.count())
+                    .select_from(User)
+                    .filter_by(confirmed_at=None)
+                )
                 if current_user.has_role("admin")
                 else None
             ),

--- a/spkrepo/views/frontend.py
+++ b/spkrepo/views/frontend.py
@@ -23,6 +23,7 @@ frontend = Blueprint("frontend", __name__)
 
 @frontend.route("/")
 def index():
+    """Render the site's home page."""
     return render_template("frontend/index.html")
 
 
@@ -41,6 +42,11 @@ def _generate_api_key():
 @frontend.route("/profile", methods=["GET", "POST"])
 @login_required
 def profile():
+    """Render the current user's profile page.
+
+    Developers additionally see an API key generation form; submitting
+    it regenerates their API key.
+    """
     if not current_user.has_role("developer"):
         return render_template(
             "frontend/profile.html",
@@ -61,10 +67,13 @@ def profile():
 
 @frontend.route("/packages")
 def packages():
+    """Render the package list page, showing each package's latest
+    version. Results are cached for 5 minutes under "packages_versions".
+    """
     versions = cache.get("packages_versions")
     if versions is None:
         latest_version = (
-            db.session.query(
+            db.select(
                 Version.package_id, db.func.max(Version.version).label("latest_version")
             )
             .join(Build)
@@ -72,24 +81,34 @@ def packages():
             .subquery()
         )
         versions = (
-            Version.query.join(Version.package)
-            .options(
-                db.joinedload(Version.package).joinedload(Package.download_counts),
-                db.joinedload(Version.package).undefer(Package.has_active_builds),
-                db.selectinload(Version.icons),
-                db.selectinload(Version.displaynames).joinedload(DisplayName.language),
-                db.selectinload(Version.builds)
-                .selectinload(Build.descriptions)
-                .joinedload(BuildDescription.language),
+            db.session.execute(
+                db.select(Version)
+                .join(Version.package)
+                .options(
+                    # Version.icons/displaynames/builds are one-to-many
+                    # collections; selectinload avoids the Cartesian-product
+                    # row multiplication joinedload would cause here.
+                    db.joinedload(Version.package).joinedload(Package.download_counts),
+                    db.joinedload(Version.package).undefer(Package.has_active_builds),
+                    db.selectinload(Version.icons),
+                    db.selectinload(Version.displaynames).joinedload(
+                        DisplayName.language
+                    ),
+                    db.selectinload(Version.builds)
+                    .selectinload(Build.descriptions)
+                    .joinedload(BuildDescription.language),
+                )
+                .join(
+                    latest_version,
+                    db.and_(
+                        Version.package_id == latest_version.c.package_id,
+                        Version.version == latest_version.c.latest_version,
+                    ),
+                )
+                .order_by(Package.name)
             )
-            .join(
-                latest_version,
-                db.and_(
-                    Version.package_id == latest_version.c.package_id,
-                    Version.version == latest_version.c.latest_version,
-                ),
-            )
-            .order_by(Package.name)
+            .unique()
+            .scalars()
             .all()
         )
         cache.set("packages_versions", versions, timeout=300)
@@ -98,16 +117,26 @@ def packages():
 
 @frontend.route("/package/<name>")
 def package(name):
+    """Render a single package's detail page, showing its full version
+    history. Returns 404 if the package doesn't exist or has no versions.
+    """
     pkg = (
-        Package.query.filter_by(name=name)
-        .options(
-            db.joinedload(Package.download_counts),
-            db.selectinload(Package.versions).selectinload(Version.icons),
-            db.selectinload(Package.versions).selectinload(Version.displaynames),
-            db.selectinload(Package.versions)
-            .selectinload(Version.builds)
-            .selectinload(Build.descriptions),
+        db.session.execute(
+            db.select(Package)
+            .filter_by(name=name)
+            .options(
+                # Same Cartesian-product concern as /packages — selectinload
+                # for one-to-many collections instead of stacking joinedloads.
+                db.joinedload(Package.download_counts),
+                db.selectinload(Package.versions).selectinload(Version.icons),
+                db.selectinload(Package.versions).selectinload(Version.displaynames),
+                db.selectinload(Package.versions)
+                .selectinload(Version.builds)
+                .selectinload(Build.descriptions),
+            )
         )
+        .unique()
+        .scalars()
         .first()
     )
     if pkg is None or not pkg.versions:
@@ -116,11 +145,15 @@ def package(name):
 
 
 def unique_user_username(form, field):
+    """WTForms validator: reject usernames that are already taken."""
     if user_datastore.find_user(username=field.data) is not None:
         raise ValidationError("Username already taken")
 
 
 class SpkrepoRegisterForm(RegisterFormV2):
+    """Flask-Security registration form extended with a required, unique
+    username field."""
+
     username = StringField(
         "Username", [InputRequired(), Length(min=4), unique_user_username]
     )

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -328,7 +328,7 @@ def catalog():
                     "version": "2.1.2-4",
                     "dname": "Git",
                     "desc": "Distributed version control system.",
-                    "link": "https://example.com/nas/git/4/git.v4.f64570%5Bx86_64%5D.spk?arch=x86_64&build=64570",
+                    "link": "https://example.com/.../git.v4.f64570%5Bx86_64%5D.spk",
                     "thumbnail": ["https://example.com/nas/git/4/icon_72.png"],
                     "qinst": true,
                     "qupgrade": true,

--- a/spkrepo/views/nas.py
+++ b/spkrepo/views/nas.py
@@ -31,16 +31,26 @@ nas = Blueprint("nas", __name__)
 
 @cache.memoize(timeout=600)
 def is_valid_arch(arch):
+    """Return True if arch is a known Architecture code."""
     return Architecture.find(arch) is not None
 
 
 @cache.memoize(timeout=600)
 def is_valid_language(language):
+    """Return True if language is a known Language code."""
     return Language.find(language) is not None
 
 
 @cache.memoize(timeout=600)
 def get_catalog(arch, build, major, language, beta):
+    """Build the package catalog for one (arch, build, major, language,
+    beta) combination.
+
+    Returns a list of package dicts for DSM < 5.1, or a dict with
+    "packages" (and "keyrings" for DSM 6 only) otherwise. Memoized for
+    10 minutes; clear_catalog_cache() invalidates all entries when build
+    or version data changes.
+    """
     # Raise work_mem for this transaction only to avoid the catalog sort
     # spilling to disk (observed: 6.9 MB spill with default work_mem).
     if db.engine.dialect.name == "postgresql":
@@ -50,7 +60,7 @@ def get_catalog(arch, build, major, language, beta):
     firmware_max_alias = aliased(Firmware)
 
     # Step 1: Get the latest version for each package
-    latest_version = db.session.query(
+    latest_version = db.select(
         Version.package_id, db.func.max(Version.version).label("latest_version")
     ).select_from(Version)
 
@@ -86,7 +96,7 @@ def get_catalog(arch, build, major, language, beta):
 
     # Step 2: Get the latest firmware for each version
     latest_firmware = (
-        db.session.query(
+        db.select(
             Version.package_id,
             latest_version.c.latest_version,
             db.func.max(firmware_min_alias.build).label("latest_firmware"),
@@ -120,33 +130,49 @@ def get_catalog(arch, build, major, language, beta):
     # times per catalog request.
     firmware_min_for_build = aliased(Firmware)
     latest_build = (
-        Build.query.options(
-            db.selectinload(Build.architectures),
-            db.joinedload(Build.firmware_min),
-            db.joinedload(Build.firmware_max),
-            db.joinedload(Build.version).joinedload(Version.package),
-            db.joinedload(Build.version).selectinload(Version.icons),
-            db.joinedload(Build.version)
-            .selectinload(Version.displaynames)
-            .joinedload(DisplayName.language),
-            db.selectinload(Build.descriptions).joinedload(BuildDescription.language),
-            db.joinedload(Build.version, Version.package).selectinload(
-                Package.screenshots
-            ),
-            db.joinedload(Build.buildmanifest),
+        db.session.execute(
+            db.select(Build)
+            .options(
+                # Build.architectures/version/firmware_min/firmware_max are
+                # lazy=False (models.py), so joined by default. Collections
+                # below use selectinload, not joinedload, to avoid Cartesian-
+                # product row multiplication when eager-loading several at once.
+                db.selectinload(Build.architectures),
+                db.joinedload(Build.firmware_min),
+                db.joinedload(Build.firmware_max),
+                db.joinedload(Build.version).joinedload(Version.package),
+                db.joinedload(Build.version).selectinload(Version.icons),
+                db.joinedload(Build.version)
+                .selectinload(Version.displaynames)
+                .joinedload(DisplayName.language),
+                db.selectinload(Build.descriptions).joinedload(
+                    BuildDescription.language
+                ),
+                db.joinedload(Build.version, Version.package).selectinload(
+                    Package.screenshots
+                ),
+                db.joinedload(Build.buildmanifest),
+            )
+            .join(Build.architectures)
+            .filter(db.or_(Architecture.code == arch, Architecture.code == "noarch"))
+            .join(firmware_min_for_build, Build.firmware_min)
+            .join(Version)
+            .join(
+                latest_firmware,
+                db.and_(
+                    Version.package_id == latest_firmware.c.package_id,
+                    Version.version == latest_firmware.c.latest_version,
+                    firmware_min_for_build.build == latest_firmware.c.latest_firmware,
+                ),
+            )
         )
-        .join(Build.architectures)
-        .filter(db.or_(Architecture.code == arch, Architecture.code == "noarch"))
-        .join(firmware_min_for_build, Build.firmware_min)
-        .join(Version)
-        .join(
-            latest_firmware,
-            db.and_(
-                Version.package_id == latest_firmware.c.package_id,
-                Version.version == latest_firmware.c.latest_version,
-                firmware_min_for_build.build == latest_firmware.c.latest_firmware,
-            ),
-        )
+        # unique() is required (and good practice generally) whenever a
+        # query's joins could yield more than one row per Build — here,
+        # joining the many-to-many Build.architectures for filtering can
+        # do that — so entities are de-duplicated by identity before
+        # converting to a plain list.
+        .unique()
+        .scalars()
         .all()
     )
 
@@ -155,9 +181,11 @@ def get_catalog(arch, build, major, language, beta):
     package_ids = [b.version.package_id for b in latest_build]
     counts_by_package = {
         row.package_id: row
-        for row in PackageDownloadCounts.query.filter(
-            PackageDownloadCounts.package_id.in_(package_ids)
-        )
+        for row in db.session.execute(
+            db.select(PackageDownloadCounts).filter(
+                PackageDownloadCounts.package_id.in_(package_ids)
+            )
+        ).scalars()
     }
 
     # Step 5: Construct response with "packages"
@@ -191,6 +219,8 @@ def _set_if_truthy(entry, key, value):
 
 
 def build_package_entry(b, language, arch, build, counts_by_package):
+    """Build one package's catalog dict entry from a Build, in the shape
+    expected by DSM/SRM package_update clients."""
     counts = counts_by_package.get(b.version.package_id)
     entry = {
         "package": b.version.package.name,
@@ -266,6 +296,54 @@ def clear_catalog_cache():
 
 @nas.route("/", methods=["POST", "GET"])
 def catalog():
+    """Return the package catalog for a DSM/SRM device.
+
+    This is the endpoint DSM/SRM devices poll to discover packages
+    available for their architecture, firmware, and language. The
+    response shape depends on the ``build`` firmware number: builds
+    below ``5004`` get a bare list, builds from ``5004`` up to (but not
+    including) ``40000`` (DSM 6) additionally get a ``keyrings`` entry,
+    and DSM 7+ builds (``40000`` and above) get ``packages`` only.
+
+    :query build: the device's firmware build number (required)
+    :query arch: the device's CPU architecture code, as reported by
+        DSM/SRM (required)
+    :query language: the device's language code, e.g. ``enu`` (required)
+    :query major: the DSM/SRM major version; inferred from ``build``
+        against known firmware if omitted
+    :query package_update_channel: set to ``beta`` to include beta
+        packages (DSM < 7 only; ignored otherwise)
+
+    **Example response** (DSM 7+):
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+            "packages": [
+                {
+                    "package": "git",
+                    "version": "2.1.2-4",
+                    "dname": "Git",
+                    "desc": "Distributed version control system.",
+                    "link": "https://example.com/nas/git/4/git.v4.f64570%5Bx86_64%5D.spk?arch=x86_64&build=64570",
+                    "thumbnail": ["https://example.com/nas/git/4/icon_72.png"],
+                    "qinst": true,
+                    "qupgrade": true,
+                    "qstart": false,
+                    "download_count": 1024,
+                    "recent_download_count": 87
+                }
+            ]
+        }
+
+    :statuscode 200: catalog returned
+    :statuscode 400: a required parameter is missing and the client did
+        not request an HTML response (browsers are redirected instead)
+    :statuscode 422: ``language``, ``arch``, or ``build`` is invalid
+    """
     if (
         "build" not in request.values
         or "arch" not in request.values
@@ -299,8 +377,12 @@ def catalog():
             abort(422)
     else:
         closest_firmware = (
-            Firmware.query.filter(Firmware.build <= build, Firmware.type == "dsm")
-            .order_by(Firmware.build.desc())
+            db.session.execute(
+                db.select(Firmware)
+                .filter(Firmware.build <= build, Firmware.type == "dsm")
+                .order_by(Firmware.build.desc())
+            )
+            .scalars()
             .first()
         )
         if not closest_firmware or not closest_firmware.version:
@@ -313,4 +395,11 @@ def catalog():
 
 @nas.route("/<path:path>")
 def data(path):
+    """Serve a file (SPK, icon, or screenshot) from local storage.
+
+    :param path: relative file path under DATA_PATH, as returned by the
+        catalog's ``link``/``thumbnail``/``snapshot`` URLs
+    :statuscode 200: file returned
+    :statuscode 404: no file exists at the given path
+    """
     return send_from_directory(current_app.config["DATA_PATH"], path)


### PR DESCRIPTION
## Summary

Modernize all SQLAlchemy queries to 2.0 `select()` style, add comprehensive model docstrings, document CLI commands, fix `create_admin` UX, and remove dead code.

## Changes

### Documentation
- Add docstrings to every model class and method in `models.py` (Build, Version, Package, User, etc.)
- Add `docs/cli.rst` documenting all `flask spkrepo` commands
- Enable `celery.contrib.sphinx` extension for Celery task autodoc
- Document the NAS catalog endpoint (`GET/POST /nas/`) response format and parameters
- Add requirement note to Rehome action: "Build must be inactive and in Object Storage"

### SQLAlchemy 2.0 migration
- Replace all `Model.query` and `db.session.query(Model)` calls with `db.session.execute(db.select(Model))` across views, CLI, tests, and admin dashboard
- Add `.unique().scalars()` where joined eager loads on collections require deduplication
- Extract `get_only_build()` test helper to reduce repetition in `test_api.py`

### CLI fixes
- Add `prompt=True` to `--username` and `--email` options of `create_admin` (previously used defaults silently)
- Early return when user already exists — prints "No changes made." instead of falling through to role assignment
- Use `Role.find()` helper for cleaner role lookups

### Cleanup
- Remove dead `storage_location` property from `Build` model (checked filesystem but was never called)

## Files changed

| File | Changes |
|------|---------|
| `docs/cli.rst` | New — CLI command reference |
| `docs/admin.rst` | +1 line — Rehome requirement note |
| `docs/conf.py` | +2 lines — celery sphinx extension |
| `docs/index.rst` | +1 line — cli toctree entry |
| `spkrepo/models.py` | Removed `storage_location` property, added docstrings |
| `spkrepo/utils.py` | Docstring clarification |
| `spkrepo/cli.py` | Modernized queries, fixed prompts, early return |
| `spkrepo/views/admin.py` | Modernized dashboard counts queries |
| `spkrepo/views/frontend.py` | Modernized queries, added `.unique().scalars()` |
| `spkrepo/views/nas.py` | Modernized catalog query, added endpoint docstring |
| `spkrepo/tests/common.py` | Modernized factory queries |
| `spkrepo/tests/test_api.py` | Modernized queries, added `get_only_build()` |
| `spkrepo/tests/test_admin_actions.py` | Modernized queries |
| `spkrepo/tests/test_admin_core.py` | Modernized queries |
| `spkrepo/tests/test_nas.py` | Modernized queries |
| `spkrepo/tests/test_utils.py` | Modernized queries |
