### PR TITLE
feat: require admin activation for new user registrations

### DIFF
--- a/spkrepo/app.py
+++ b/spkrepo/app.py
@@ -5,6 +5,7 @@ import sys
 import jinja2
 from flask import Flask, request
 from flask_admin import Admin
+from flask_security.signals import user_registered
 
 from . import config as default_config
 from .cli import spkrepo as spkrepo_cli
@@ -104,6 +105,12 @@ def create_app(config=None, register_blueprints=True, init_admin=True):
 
     # Auth
     security.init_app(app, user_datastore, register_form=SpkrepoRegisterForm)
+
+    @user_registered.connect_via(app)
+    def _on_user_registered(sender, user, **extra):
+        """New registrations start inactive — an admin must activate them."""
+        user.active = False
+        db.session.commit()
 
     # Services
     mail.init_app(app)


### PR DESCRIPTION
## Summary

Require admin approval before newly self-registered users can log in.

## Changes

**`spkrepo/app.py`** — Register a Flask-Security `user_registered` signal handler that sets `user.active = False` on new registrations.

Flow:
1. User registers via `/register`
2. Confirmation email sent — user clicks link → `confirmed_at` set
3. Account remains **inactive** (`active = False`)
4. Admin manually activates the user via the **User admin view** (toggle `active` checkbox)
5. User can now log in

Existing CLI commands (`create_user`, `create_admin`) are unaffected — they set `active = True` as before.