### PR TITLE
fix: add percentage to chart tooltips

### DIFF
--- a/spkrepo/templates/admin/index.html
+++ b/spkrepo/templates/admin/index.html
@@ -181,7 +181,18 @@
       tooltip: {
         callbacks: {
           label: function(ctx) {
-            return (ctx.dataset.label ? ctx.dataset.label + ': ' : '') + ctx.parsed.x.toLocaleString();
+            var val = ctx.parsed.x;
+            var total;
+            if (ctx.dataset.label) {
+              var i = ctx.dataIndex;
+              total = 0;
+              ctx.chart.data.datasets.forEach(function(ds) { total += ds.data[i]; });
+            } else {
+              total = ctx.dataset.data.reduce(function(a, b) { return a + b; }, 0);
+            }
+            var pct = total > 0 ? (val / total * 100).toFixed(1) : 0;
+            return (ctx.dataset.label ? ctx.dataset.label + ': ' : '') +
+              val.toLocaleString() + ' (' + pct + '%)';
           }
         }
       }


### PR DESCRIPTION
## Summary

Add percentage values to admin chart tooltips for both simple and stacked bar charts.

## Changes

**`spkrepo/templates/admin/index.html`** — Updated the Chart.js tooltip `label` callback to append a percentage:

- **Simple charts** (DSM Versions, Architectures): percentage of total across all bars in the current time range
- **Stacked chart** (Packages by Version): percentage of that version's share within the package's total

Tooltips now show: `50.2k downloads (44.3%)`