### PR TITLE
feat: default sort packages by name

### DIFF
--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -915,6 +915,7 @@ class PackageView(ModelView):
         ),
         ("last_download_date", "last_download_date"),
     )
+    column_default_sort = "name"
     column_formatters = {
         "insert_date": lambda v, c, m, p: (
             m.insert_date.strftime("%Y-%m-%d") if m.insert_date else None


### PR DESCRIPTION
## Summary

Set the default sort order for the admin Packages view to sort alphabetically by package name.

## Changes

**`spkrepo/views/admin.py`** — Added `column_default_sort = "name"` to `PackageView`, matching the alphabetical ordering used on the frontend `/packages` page. Previously the view used Flask-Admin's default (primary key / insertion order).
