### PR TITLE
feat: add prev/next navigation and sectioned layout to admin details views

### DIFF
--- a/spkrepo/templates/admin/_details_nav.html
+++ b/spkrepo/templates/admin/_details_nav.html
@@ -1,0 +1,13 @@
+{% if prev_id or next_id %}
+<div class="d-flex justify-content-between align-items-center mt-3 mb-3">
+  <a class="btn btn-secondary btn-sm{% if not prev_id %} disabled{% endif %}"
+     href="{% if prev_id %}{{ get_url('.details_view', id=prev_id, url=return_url) }}{% else %}javascript:void(0){% endif %}">
+    &larr; Previous
+  </a>
+  <span class="text-muted">{{ current_pos }} / {{ current_total }}</span>
+  <a class="btn btn-secondary btn-sm{% if not next_id %} disabled{% endif %}"
+     href="{% if next_id %}{{ get_url('.details_view', id=next_id, url=return_url) }}{% else %}javascript:void(0){% endif %}">
+    Next &rarr;
+  </a>
+</div>
+{% endif %}

--- a/spkrepo/templates/admin/model/details.html
+++ b/spkrepo/templates/admin/model/details.html
@@ -1,0 +1,56 @@
+{% extends 'admin/master.html' %}
+{% import 'admin/lib.html' as lib with context %}
+
+{% block body %}
+  {% block navlinks %}
+  <ul class="nav nav-tabs">
+    <li class="nav-item">
+        <a class="nav-link" href="{{ return_url }}">{{ _gettext('List') }}</a>
+    </li>
+    {%- if admin_view.can_create -%}
+    <li class="nav-item">
+        <a class="nav-link" href="{{ get_url('.create_view', url=return_url) }}">{{ _gettext('Create') }}</a>
+    </li>
+    {%- endif -%}
+    {%- if admin_view.can_edit -%}
+    <li class="nav-item">
+        <a class="nav-link" href="{{ get_url('.edit_view', id=request.args.get('id'), url=return_url) }}">{{ _gettext('Edit') }}</a>
+    </li>
+    {%- endif -%}
+    <li class="nav-item">
+        <a class="nav-link active disabled" href="javascript:void(0)">{{ _gettext('Details') }}</a>
+    </li>
+  </ul>
+  {% endblock %}
+
+  {% block details_nav %}
+    {% include 'admin/_details_nav.html' %}
+  {% endblock %}
+
+  {% block details_search %}
+    <div class="form-inline fa_filter_container col-lg-6">
+      <label for="fa_filter">{{ _gettext('Filter') }}</label>
+      <input id="fa_filter" type="text" class="ml-3 form-control">
+    </div>
+  {% endblock %}
+
+  {% block details_table %}
+    <table class="table table-hover table-bordered searchable">
+    {% for c, name in details_columns %}
+      <tr>
+        <td>
+          <b>{{ name }}</b>
+        </td>
+        <td>
+        {{ get_value(model, c) }}
+        </td>
+      </tr>
+    {% endfor %}
+    </table>
+  {% endblock %}
+{% endblock %}
+
+{% block tail %}
+  {{ super() }}
+  <script {{ admin_csp_nonce_attribute }} src="{{ admin_static.url(filename='admin/js/details_filter.js', v='1.0.0') }}"></script>
+{% endblock %}

--- a/spkrepo/templates/admin/model/details.html
+++ b/spkrepo/templates/admin/model/details.html
@@ -36,15 +36,24 @@
 
   {% block details_table %}
     <table class="table table-hover table-bordered searchable">
-    {% for c, name in details_columns %}
+    {% for title, cols in details_sections %}
       <tr>
-        <td>
-          <b>{{ name }}</b>
-        </td>
-        <td>
-        {{ get_value(model, c) }}
-        </td>
+        <td rowspan="{{ cols|length }}" class="align-middle font-weight-bold table-secondary" style="width: 140px;{% if not loop.last %} border-bottom: 1px solid #adb5bd;{% endif %}">{{ title }}</td>
+        {% for c, name in cols %}
+          {% if loop.first %}
+        <td><b>{{ name }}</b></td>
+        <td>{{ get_value(model, c) }}</td>
+          {% endif %}
+        {% endfor %}
       </tr>
+      {% for c, name in cols %}
+        {% if not loop.first %}
+      <tr>
+        <td><b>{{ name }}</b></td>
+        <td>{{ get_value(model, c) }}</td>
+      </tr>
+        {% endif %}
+      {% endfor %}
     {% endfor %}
     </table>
   {% endblock %}

--- a/spkrepo/templates/admin/package_detail.html
+++ b/spkrepo/templates/admin/package_detail.html
@@ -23,6 +23,10 @@
   </ul>
   {% endblock %}
 
+  {% block details_nav %}
+    {% include 'admin/_details_nav.html' %}
+  {% endblock %}
+
   {% block details_search %}
     <div class="form-inline fa_filter_container col-lg-6">
       <label for="fa_filter">{{ _gettext('Filter') }}</label>

--- a/spkrepo/templates/admin/package_detail.html
+++ b/spkrepo/templates/admin/package_detail.html
@@ -35,62 +35,68 @@
   {% endblock %}
 
   {% block details_table %}
-    <table class="table table-hover table-bordered searchable">
-      {% for c, name in details_columns %}
-        <tr>
-          <td><b>{% if c == 'recent_download_count' %}Downloads (90d){% else %}{{ name }}{% endif %}</b></td>
-          <td>
-            {% if c == 'arch_breakdown' %}
-              {% if arch_breakdown %}
-                <table style="width: 100%; max-width: 380px; border: none; border-spacing: 0">
-                  {% for code, count, pct in arch_breakdown %}
-                    <tr>
-                      <td style="white-space: nowrap; padding-right: 10px; font-family: monospace; width: 1%">
-                        {{ code }}
-                      </td>
-                      <td style="width: 100%; padding-right: 10px">
-                        <div style="background: #e9ecef; border-radius: 3px; height: 14px">
-                          <div style="background: #5b9bd5; border-radius: 3px; height: 14px; width: {{ pct | round(1) }}%"></div>
-                        </div>
-                      </td>
-                      <td style="white-space: nowrap; color: #666; font-size: 0.9em">
-                        {{ "{:,}".format(count) }} ({{ pct | round | int }}%)
-                      </td>
-                    </tr>
-                  {% endfor %}
-                </table>
-              {% else %}
-                <span class="text-muted">No NAS downloads in the last 90 days</span>
-              {% endif %}
-            {% elif c == 'firmware_breakdown' %}
-              {% if firmware_breakdown %}
-                <table style="width: 100%; max-width: 380px; border: none; border-spacing: 0">
-                  {% for label, count, pct in firmware_breakdown %}
-                    <tr>
-                      <td style="white-space: nowrap; padding-right: 10px; font-family: monospace; width: 1%">
-                        {{ label }}
-                      </td>
-                      <td style="width: 100%; padding-right: 10px">
-                        <div style="background: #e9ecef; border-radius: 3px; height: 14px">
-                          <div style="background: #e67e22; border-radius: 3px; height: 14px; width: {{ pct | round(1) }}%"></div>
-                        </div>
-                      </td>
-                      <td style="white-space: nowrap; color: #666; font-size: 0.9em">
-                        {{ "{:,}".format(count) }} ({{ pct | round | int }}%)
-                      </td>
-                    </tr>
-                  {% endfor %}
-                </table>
-              {% else %}
-                <span class="text-muted">No NAS downloads in the last 90 days</span>
-              {% endif %}
-            {% else %}
-              {{ get_value(model, c) }}
-            {% endif %}
-          </td>
-        </tr>
+  {% macro detail_row(c, name) %}
+    <td><b>{% if c == 'recent_download_count' %}Downloads (90d){% else %}{{ name }}{% endif %}</b></td>
+    <td>
+      {% if c == 'arch_breakdown' %}
+        {% if arch_breakdown %}
+          <table style="width: 100%; max-width: 380px; border: none; border-spacing: 0">
+            {% for code, count, pct in arch_breakdown %}
+              <tr>
+                <td style="white-space: nowrap; padding-right: 10px; font-family: monospace; width: 1%">{{ code }}</td>
+                <td style="width: 100%; padding-right: 10px">
+                  <div style="background: #e9ecef; border-radius: 3px; height: 14px">
+                    <div style="background: #5b9bd5; border-radius: 3px; height: 14px; width: {{ pct | round(1) }}%"></div>
+                  </div>
+                </td>
+                <td style="white-space: nowrap; color: #666; font-size: 0.9em">
+                  {{ "{:,}".format(count) }} ({{ pct | round | int }}%)
+                </td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% else %}
+          <span class="text-muted">No NAS downloads in the last 90 days</span>
+        {% endif %}
+      {% elif c == 'firmware_breakdown' %}
+        {% if firmware_breakdown %}
+          <table style="width: 100%; max-width: 380px; border: none; border-spacing: 0">
+            {% for label, count, pct in firmware_breakdown %}
+              <tr>
+                <td style="white-space: nowrap; padding-right: 10px; font-family: monospace; width: 1%">{{ label }}</td>
+                <td style="width: 100%; padding-right: 10px">
+                  <div style="background: #e9ecef; border-radius: 3px; height: 14px">
+                    <div style="background: #e67e22; border-radius: 3px; height: 14px; width: {{ pct | round(1) }}%"></div>
+                  </div>
+                </td>
+                <td style="white-space: nowrap; color: #666; font-size: 0.9em">
+                  {{ "{:,}".format(count) }} ({{ pct | round | int }}%)
+                </td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% else %}
+          <span class="text-muted">No NAS downloads in the last 90 days</span>
+        {% endif %}
+      {% else %}
+        {{ get_value(model, c) }}
+      {% endif %}
+    </td>
+  {% endmacro %}
+
+  <table class="table table-hover table-bordered searchable">
+    {% for title, cols in details_sections %}
+      <tr>
+        <td rowspan="{{ cols|length }}" class="align-middle font-weight-bold table-secondary" style="width: 140px;{% if not loop.last %} border-bottom: 1px solid #adb5bd;{% endif %}">{{ title }}</td>
+        {% for c, name in cols %}
+          {% if loop.first %}{{ detail_row(c, name) }}{% endif %}
+        {% endfor %}
+      </tr>
+      {% for c, name in cols %}
+        {% if not loop.first %}<tr>{{ detail_row(c, name) }}</tr>{% endif %}
       {% endfor %}
-    </table>
+    {% endfor %}
+  </table>
   {% endblock %}
 {% endblock %}
 

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -1137,8 +1137,8 @@ class VersionView(DetailsNavigationMixin, SignResyncMixin, ModelView):
 
     column_list = (
         "package",
-        "upstream_version",
         "version",
+        "upstream_version",
         "beta",
         "startable",
         "all_builds_active",
@@ -1396,9 +1396,9 @@ class BuildView(DetailsNavigationMixin, SignResyncMixin, ModelView):
         "architectures",
         "firmware_min",
         "publisher",
-        "insert_date",
-        "storage",
         "active",
+        "storage",
+        "insert_date",
     )
     column_labels = {
         "version.package": "Package",

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import uuid
 from datetime import date, timedelta
+from urllib.parse import parse_qs, urlparse
 
 from celery.result import AsyncResult
 from flask import (
@@ -745,7 +746,89 @@ class ScreenshotView(ModelView):
     }
 
 
-class PackageView(ModelView):
+class DetailsNavigationMixin:
+    """Add prev/next navigation to the admin details view.
+
+    Computes the previous and next record IDs relative to the current
+    one, honoring the originating list view's sort, filters, and search.
+    Exposes them to the template as ``prev_id`` / ``next_id``.
+    """
+
+    def _active_filters(self):
+        """Return the filters active on the originating list view.
+
+        The details URL carries the list view's URL (with its ``flt*``
+        query params) in the ``url`` argument; parse those back into the
+        (index, name, value) tuples Flask-Admin expects.
+        """
+        return_url = request.args.get("url", "")
+        if not return_url or not self._filter_args:
+            return []
+        qs = parse_qs(urlparse(return_url).query)
+        filters = []
+        for arg, values in qs.items():
+            if not arg.startswith("flt") or "_" not in arg or not values:
+                continue
+            pos, key = arg[3:].split("_", 1)
+            if key in self._filter_args:
+                idx, flt = self._filter_args[key]
+                value = values[0]
+                if flt.validate(value):
+                    filters.append((int(pos), (idx, flt.name, value)))
+        return [f[1] for f in sorted(filters, key=lambda n: n[0])]
+
+    def _list_args(self):
+        """Return (sort_idx, desc, search) from the list view's return URL."""
+        return_url = request.args.get("url", "")
+        sort_idx = None
+        desc = False
+        search = None
+        if return_url:
+            qs = parse_qs(urlparse(return_url).query)
+            if "sort" in qs and qs["sort"][0]:
+                sort_idx = int(qs["sort"][0])
+                desc = "desc" in qs and qs["desc"][0] == "1"
+            if "search" in qs and qs["search"][0]:
+                search = qs["search"][0]
+        return sort_idx, desc, search
+
+    def _adjacent_ids(self, obj_id):
+        query = self.get_query()
+        joins = {}
+
+        filters = self._active_filters()
+        if filters:
+            query, _, joins, _ = self._apply_filters(query, None, joins, {}, filters)
+
+        sort_idx, desc, search = self._list_args()
+        if search:
+            query, _, joins, _ = self._apply_search(query, None, joins, {}, search)
+        query, joins = self._apply_sorting(query, joins, sort_idx, desc)
+
+        ids = [row[0] for row in query.with_entities(self.model.id).all()]
+        if obj_id not in ids:
+            return None, None
+        pos = ids.index(obj_id)
+        prev_id = ids[pos - 1] if pos > 0 else None
+        next_id = ids[pos + 1] if pos < len(ids) - 1 else None
+        self._current_pos = pos + 1
+        self._current_total = len(ids)
+        return prev_id, next_id
+
+    @expose("/details/")
+    def details_view(self):
+        obj_id = request.args.get("id", type=int)
+        self._current_pos = None
+        self._current_total = None
+        prev_id, next_id = self._adjacent_ids(obj_id) if obj_id else (None, None)
+        self._template_args["prev_id"] = prev_id
+        self._template_args["next_id"] = next_id
+        self._template_args["current_pos"] = self._current_pos
+        self._template_args["current_total"] = self._current_total
+        return super().details_view()
+
+
+class PackageView(DetailsNavigationMixin, ModelView):
     """View for :class:`~spkrepo.models.Package`"""
 
     def __init__(self, **kwargs):
@@ -973,7 +1056,7 @@ class PackageView(ModelView):
     form_args = {"name": {"validators": [Regexp(SPK.package_re)]}}
 
 
-class VersionView(SignResyncMixin, ModelView):
+class VersionView(DetailsNavigationMixin, SignResyncMixin, ModelView):
     """View for :class:`~spkrepo.models.Version`"""
 
     def __init__(self, **kwargs):
@@ -1231,7 +1314,7 @@ class VersionView(SignResyncMixin, ModelView):
             )
 
 
-class BuildView(SignResyncMixin, ModelView):
+class BuildView(DetailsNavigationMixin, SignResyncMixin, ModelView):
     """View for :class:`~spkrepo.models.Build`"""
 
     def __init__(self, **kwargs):
@@ -1312,6 +1395,24 @@ class BuildView(SignResyncMixin, ModelView):
         "storage": _storage_formatter,
         "active": _bool_formatter,
     }
+    column_details_list = (
+        "version.package",
+        "version.version",
+        "version.upstream_version",
+        "architectures",
+        "firmware_min",
+        "firmware_max",
+        "publisher",
+        "path",
+        "size",
+        "md5",
+        "checksum",
+        "changelog",
+        "signed",
+        "active",
+        "storage",
+        "insert_date",
+    )
     column_formatters_detail = {
         "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
         "size": lambda v, c, m, p: (

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -815,6 +815,21 @@ class DetailsNavigationMixin:
         self._current_total = len(ids)
         return prev_id, next_id
 
+    def _details_sections(self):
+        """Build [(title, [(column, label), ...]), ...] for the template.
+
+        Groups ``column_details_list`` by the view's ``details_sections``
+        mapping, preserving column order and resolving labels.
+        """
+        labels = dict(self._details_columns)
+        sections = getattr(self, "details_sections", None)
+        if not sections:
+            return [("", labels.items())]
+        result = []
+        for title, cols in sections.items():
+            result.append((title, [(c, labels[c]) for c in cols if c in labels]))
+        return result
+
     @expose("/details/")
     def details_view(self):
         obj_id = request.args.get("id", type=int)
@@ -825,6 +840,7 @@ class DetailsNavigationMixin:
         self._template_args["next_id"] = next_id
         self._template_args["current_pos"] = self._current_pos
         self._template_args["current_total"] = self._current_total
+        self._template_args["details_sections"] = self._details_sections()
         return super().details_view()
 
 
@@ -1051,6 +1067,19 @@ class PackageView(DetailsNavigationMixin, ModelView):
         "arch_breakdown",
         "firmware_breakdown",
     )
+    details_sections = {
+        "Identity": ("name",),
+        "People": ("author", "maintainers"),
+        "Status": ("has_active_builds",),
+        "Date": ("insert_date",),
+        "Analytics": (
+            "download_count",
+            "recent_download_count",
+            "last_download_date",
+            "arch_breakdown",
+            "firmware_breakdown",
+        ),
+    }
 
     form_columns = ("name", "author", "maintainers")
     form_args = {"name": {"validators": [Regexp(SPK.package_re)]}}
@@ -1135,6 +1164,23 @@ class VersionView(DetailsNavigationMixin, SignResyncMixin, ModelView):
         "recent_download_count",
         "last_download_date",
     )
+    details_sections = {
+        "Identity": ("package", "version", "upstream_version"),
+        "Metadata": (
+            "report_url",
+            "distributor",
+            "distributor_url",
+            "maintainer",
+            "maintainer_url",
+        ),
+        "Features": ("install_wizard", "upgrade_wizard", "startable", "license"),
+        "Date": ("insert_date",),
+        "Analytics": (
+            "download_count",
+            "recent_download_count",
+            "last_download_date",
+        ),
+    }
     column_labels = {
         "package.name": "Package Name",
         "version_string": "Version",
@@ -1413,6 +1459,14 @@ class BuildView(DetailsNavigationMixin, SignResyncMixin, ModelView):
         "storage",
         "insert_date",
     )
+    details_sections = {
+        "Identity": ("version.package", "version.version", "version.upstream_version"),
+        "Targets": ("architectures", "firmware_min", "firmware_max"),
+        "People": ("publisher",),
+        "File": ("path", "size", "md5", "checksum", "changelog"),
+        "Status": ("signed", "active", "storage"),
+        "Date": ("insert_date",),
+    }
     column_formatters_detail = {
         "insert_date": lambda v, c, m, p: m.insert_date.strftime("%Y-%m-%d %H:%M:%S"),
         "size": lambda v, c, m, p: (


### PR DESCRIPTION
## Summary

Add previous/next navigation to the admin details views, group details fields into labelled sections, and align list column ordering.

## Changes

### Prev/Next navigation
- New `DetailsNavigationMixin` provides **Previous / Next** buttons on the Package, Version, and Build details screens
- Navigation honors the originating list view's **sort**, **filters**, and **search** (via the `return_url` query params)
- Shows current position (e.g. "12 / 42") between the buttons
- Reuses Flask-Admin's own `_apply_filters` / `_apply_search` / `_apply_sorting` machinery

### Sectioned details layout
- Details fields grouped into labelled sections with a vertical rowspan header on the left:
  - **Package**: Identity, People, Status, Date, Analytics
  - **Version**: Identity, Metadata, Features, Date, Analytics
  - **Build**: Identity, Targets, People, File, Status, Date
- Sections separated by a subtle 1px darker divider

### List ordering alignment
- **Version** list: `version` now before `upstream_version` (matches details)
- **Build** list: `active`, `storage`, then `insert_date` (matches details' Status → Date flow)
- Build details gained an explicit `column_details_list` showing all meaningful fields

## Files changed

| File | Changes |
|------|---------|
| `spkrepo/views/admin.py` | `DetailsNavigationMixin`, `details_sections` dicts, list reordering |
| `spkrepo/templates/admin/_details_nav.html` | New — prev/next nav partial |
| `spkrepo/templates/admin/model/details.html` | New — sectioned details template override |
| `spkrepo/templates/admin/package_detail.html` | Sectioned layout with chart handling |
