### PR TITLE
feat: allow uploading inactive builds to object storage

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -38,7 +38,8 @@ Available actions appear in the dropdown after selecting items in a list view.
 
 **03 Upload (Versions / Builds)**
     Uploads local SPK files to object storage (S3-compatible).
-    Build must be local, active, and signed.
+    Build must be local and signed. Inactive builds may be uploaded to
+    free local disk space without appearing in the catalog.
 
 **04 Rehome (Versions / Builds)**
     Downloads a build from object storage back to local disk for editing.

--- a/spkrepo/views/admin.py
+++ b/spkrepo/views/admin.py
@@ -383,8 +383,6 @@ class SignResyncMixin:
         for label, build in self._iter_builds(ids):
             if build.storage != "local":
                 continue
-            if not build.active:
-                continue
             if not build.signed and not _detect_and_fix_signed(build):
                 continue
             result = upload_to_storage.delay(build.id, str(build))
@@ -401,7 +399,7 @@ class SignResyncMixin:
             )
         else:
             flash(
-                "No builds found to upload (must be local, active, and signed).",
+                "No builds found to upload (must be local and signed).",
                 "warning",
             )
 


### PR DESCRIPTION
## Summary

Loosen the Upload action constraint so inactive builds can be uploaded to object storage, freeing local disk space without publishing them to the catalog.

## Changes

**`spkrepo/views/admin.py`** — `action_03_upload` no longer requires builds to be `active`. Upload now only requires:
- Build is **local** (`storage == "local"`)
- Build is **signed**

Inactive builds uploaded this way stay out of the NAS catalog until explicitly activated. Re-activating a remote build does not re-upload it (activate only uploads `local` builds), so the workflow is consistent.

**`docs/admin.rst`** — Updated the Upload action description.

## Rationale

The normal flow (upload SPK → activate) already uploads via the Activate action. The standalone Upload action is now useful for moving inactive builds off local disk to save space while keeping them unpublished.
