### PR TITLE
Fix ingest_logs crash on unknown architecture

### DIFF
--- a/spkrepo/cli.py
+++ b/spkrepo/cli.py
@@ -430,7 +430,7 @@ def ingest_logs():
                 if arch_code is not None:
                     if arch_code not in arch_cache:
                         arch = Architecture.find(arch_code, syno=True)
-                        arch_cache[arch_code] = arch.id
+                        arch_cache[arch_code] = arch.id if arch else None
                     architecture_id = arch_cache[arch_code]
                 else:
                     architecture_id = None


### PR DESCRIPTION
## Summary

`ingest_logs` crashes with `AttributeError: 'NoneType' object has no attribute 'id'` when a download log references an architecture code that isn't in the `architecture` table.

`Architecture.find(arch_code, syno=True)` returns `None` in that case, but the code dereferenced `arch.id` unconditionally, aborting the whole ingest and leaving log files unprocessed/undeleted (visible as repeated hourly failures in the logs).

## Fix

Store `None` instead of `arch.id` — matching the documented `arch_cache` contract (`arch_code -> architecture_id or None`) and the nullable `download_stat.architecture_id` column. Verified against the live Postgres: an insert with `architecture_id = NULL` succeeds, and `package_download_counts` groups by `package_id` only, so NULL-arch rows aggregate fine.

## Impact

- Crash eliminated; pending log files get processed and deleted.
- Package/site totals include NULL-arch rows correctly.
- Note: the `ON CONFLICT` upsert does not dedupe fully-NULL (arch/fw/missing) rows on reprocess — pre-existing behavior shared with the manual-download path, not introduced here; can be hardened separately.